### PR TITLE
fix(TNLBT-1219): slightly narrowed images on channel pages

### DIFF
--- a/packages/ts-newskit/src/components/slices/article/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/slices/article/__tests__/__snapshots__/index.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`Render Article List Item items should render without margin 1`] = `
             alt="This is ALT Text"
             class="css-ssxt4f"
             loading="lazy"
+            style="object-fit: cover;"
           />
         </picture>
       </a>
@@ -96,6 +97,7 @@ exports[`Render Article List Item should render a snapshot 1`] = `
             alt="This is ALT Text"
             class="css-ssxt4f"
             loading="lazy"
+            style="object-fit: cover;"
           />
         </picture>
       </a>

--- a/packages/ts-newskit/src/components/slices/article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/article/index.tsx
@@ -143,6 +143,7 @@ export const Article = ({
         loading="lazy"
         // NOTE: This ensures external content image renders - will be removed once CP side resolved
         style={{
+          objectFit: 'cover',
           aspectRatio:
             imageWithCorrectRatio &&
             getForcedExternalContentRatio(imageWithCorrectRatio, '3:2')

--- a/packages/ts-newskit/src/components/slices/comment-card/__tests__/__snapshots__/comment-card.test.tsx.snap
+++ b/packages/ts-newskit/src/components/slices/comment-card/__tests__/__snapshots__/comment-card.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`should render component to match snapshot 1`] = `
             alt="Journalist name"
             class="css-176aubw"
             loading="lazy"
+            style="object-fit: cover;"
             width="77px"
           />
         </picture>

--- a/packages/ts-newskit/src/components/slices/comment-card/index.tsx
+++ b/packages/ts-newskit/src/components/slices/comment-card/index.tsx
@@ -97,6 +97,7 @@ export const CommentCard = ({
               }}
               // NOTE: This ensures external content image renders - will be removed once CP side resolved
               style={{
+                objectFit: 'cover',
                 aspectRatio:
                   imageWithCorrectRatio &&
                   getForcedExternalContentRatio(imageWithCorrectRatio, '1:1')

--- a/packages/ts-newskit/src/components/slices/lead-article/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/slices/lead-article/__tests__/__snapshots__/index.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`Render Component one should render a snapshot 1`] = `
               alt="Sarcacens an inclusive club? They didnt look out for me"
               class="css-1qgqq71"
               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+              style="object-fit: cover;"
             />
           </picture>
         </a>

--- a/packages/ts-newskit/src/components/slices/lead-article/index.tsx
+++ b/packages/ts-newskit/src/components/slices/lead-article/index.tsx
@@ -183,6 +183,7 @@ export const LeadArticle = ({
                   }
                   // NOTE: This ensures external content image renders - will be removed once CP side resolved
                   style={{
+                    objectFit: 'cover',
                     aspectRatio:
                       imageWithCorrectRatio &&
                       getForcedExternalContentRatio(

--- a/packages/ts-newskit/src/slices/comment-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/comment-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`Render Comment Bucket 1 Slice Slice matches snapshot 1`] = `
                   alt="Martin Samuel"
                   class="css-176aubw"
                   loading="lazy"
+                  style="object-fit: cover;"
                   width="77px"
                 />
               </picture>
@@ -106,6 +107,7 @@ exports[`Render Comment Bucket 1 Slice Slice matches snapshot 1`] = `
                   alt="Martin Samuel"
                   class="css-176aubw"
                   loading="lazy"
+                  style="object-fit: cover;"
                   width="77px"
                 />
               </picture>
@@ -180,6 +182,7 @@ exports[`Render Comment Bucket 1 Slice Slice matches snapshot 1`] = `
                   alt="Martin Samuel"
                   class="css-176aubw"
                   loading="lazy"
+                  style="object-fit: cover;"
                   width="77px"
                 />
               </picture>

--- a/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -40,6 +40,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -189,6 +190,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -347,6 +349,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                         alt="Deborah Haynes"
                         class="css-176aubw"
                         loading="lazy"
+                        style="object-fit: cover;"
                         width="77px"
                       />
                     </picture>
@@ -434,6 +437,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                         alt="Deborah Haynes 2"
                         class="css-176aubw"
                         loading="lazy"
+                        style="object-fit: cover;"
                         width="77px"
                       />
                     </picture>
@@ -541,6 +545,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -629,6 +634,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                             alt="‘American owners pose threat to English pyramid’"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -717,6 +723,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -805,6 +812,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -898,6 +906,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -986,6 +995,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                         alt="‘American owners pose threat to English pyramid’"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -1074,6 +1084,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                         alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -1162,6 +1173,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                         alt="Blow for rebel clubs as court says Uefa can block Super League"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -1265,6 +1277,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                       alt="Deborah Haynes"
                       class="css-176aubw"
                       loading="lazy"
+                      style="object-fit: cover;"
                       width="77px"
                     />
                   </picture>
@@ -1352,6 +1365,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot 1`] = `
                       alt="Deborah Haynes 2"
                       class="css-176aubw"
                       loading="lazy"
+                      style="object-fit: cover;"
                       width="77px"
                     />
                   </picture>
@@ -1453,6 +1467,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -1602,6 +1617,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -1760,6 +1776,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                         alt="Deborah Haynes"
                         class="css-176aubw"
                         loading="lazy"
+                        style="object-fit: cover;"
                         width="77px"
                       />
                     </picture>
@@ -1847,6 +1864,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                         alt="Deborah Haynes 2"
                         class="css-176aubw"
                         loading="lazy"
+                        style="object-fit: cover;"
                         width="77px"
                       />
                     </picture>
@@ -1954,6 +1972,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2042,6 +2061,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                             alt="‘American owners pose threat to English pyramid’"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2130,6 +2150,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2218,6 +2239,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2311,6 +2333,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -2399,6 +2422,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                         alt="‘American owners pose threat to English pyramid’"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -2487,6 +2511,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                         alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -2575,6 +2600,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                         alt="Blow for rebel clubs as court says Uefa can block Super League"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -2678,6 +2704,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                       alt="Deborah Haynes"
                       class="css-176aubw"
                       loading="lazy"
+                      style="object-fit: cover;"
                       width="77px"
                     />
                   </picture>
@@ -2765,6 +2792,7 @@ exports[`Render Content Bucket 1 Slice Slice matches snapshot for mobile 1`] = `
                       alt="Deborah Haynes 2"
                       class="css-176aubw"
                       loading="lazy"
+                      style="object-fit: cover;"
                       width="77px"
                     />
                   </picture>

--- a/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -38,6 +38,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -114,6 +115,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -268,6 +270,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                         alt="‘American owners pose threat to English pyramid’"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -422,6 +425,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                         alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -576,6 +580,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`lg\` breakpoi
                         alt="Blow for rebel clubs as court says Uefa can block Super League"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -679,6 +684,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -755,6 +761,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -909,6 +916,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                         alt="‘American owners pose threat to English pyramid’"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -1063,6 +1071,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                         alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -1217,6 +1226,7 @@ exports[`Render Content Bucket 2 Slice Slice matches snapshot at \`xs\` breakpoi
                         alt="Blow for rebel clubs as court says Uefa can block Super League"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>

--- a/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/content-bucket-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                             alt="Sarcacens an inclusive club? They didnt look out for me"
                             class="css-1qgqq71"
                             src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -209,6 +210,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                             alt="Sarcacens an inclusive club? They didnt look out for me"
                             class="css-1qgqq71"
                             src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -360,6 +362,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                         alt="Deborah Haynes"
                         class="css-176aubw"
                         loading="lazy"
+                        style="object-fit: cover;"
                         width="77px"
                       />
                     </picture>
@@ -447,6 +450,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                         alt="Deborah Haynes 2"
                         class="css-176aubw"
                         loading="lazy"
+                        style="object-fit: cover;"
                         width="77px"
                       />
                     </picture>
@@ -819,6 +823,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -907,6 +912,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                         alt="‘American owners pose threat to English pyramid’"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -995,6 +1001,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                         alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -1083,6 +1090,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                         alt="Blow for rebel clubs as court says Uefa can block Super League"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -1186,6 +1194,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                       alt="Deborah Haynes"
                       class="css-176aubw"
                       loading="lazy"
+                      style="object-fit: cover;"
                       width="77px"
                     />
                   </picture>
@@ -1273,6 +1282,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot 1`] = `
                       alt="Deborah Haynes 2"
                       class="css-176aubw"
                       loading="lazy"
+                      style="object-fit: cover;"
                       width="77px"
                     />
                   </picture>
@@ -1385,6 +1395,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                             alt="Sarcacens an inclusive club? They didnt look out for me"
                             class="css-1qgqq71"
                             src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -1543,6 +1554,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                             alt="Sarcacens an inclusive club? They didnt look out for me"
                             class="css-1qgqq71"
                             src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -1694,6 +1706,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                         alt="Deborah Haynes"
                         class="css-176aubw"
                         loading="lazy"
+                        style="object-fit: cover;"
                         width="77px"
                       />
                     </picture>
@@ -1781,6 +1794,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                         alt="Deborah Haynes 2"
                         class="css-176aubw"
                         loading="lazy"
+                        style="object-fit: cover;"
                         width="77px"
                       />
                     </picture>
@@ -2153,6 +2167,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -2241,6 +2256,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                         alt="‘American owners pose threat to English pyramid’"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -2329,6 +2345,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                         alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -2417,6 +2434,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                         alt="Blow for rebel clubs as court says Uefa can block Super League"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -2520,6 +2538,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                       alt="Deborah Haynes"
                       class="css-176aubw"
                       loading="lazy"
+                      style="object-fit: cover;"
                       width="77px"
                     />
                   </picture>
@@ -2607,6 +2626,7 @@ exports[`Render Content Bucket 3 Slice Slice matches snapshot for mobile 1`] = `
                       alt="Deborah Haynes 2"
                       class="css-176aubw"
                       loading="lazy"
+                      style="object-fit: cover;"
                       width="77px"
                     />
                   </picture>

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/article-stack.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/article-stack.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -148,6 +149,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                         alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -276,6 +278,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                         alt="American owners pose threat to English pyramid 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -362,6 +365,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                         alt="American owners pose threat to English pyramid 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -457,6 +461,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                         alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -562,6 +567,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                         alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -676,6 +682,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                         alt="Blow for rebel clubs as court says Uefa can block Super League"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -772,6 +779,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                         alt="Blow for rebel clubs as court says Uefa can block Super League"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -877,6 +885,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                         alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -996,6 +1005,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                         alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -1117,6 +1127,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1226,6 +1237,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1354,6 +1366,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     alt="American owners pose threat to English pyramid 2"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1440,6 +1453,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     alt="American owners pose threat to English pyramid 2"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1535,6 +1549,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1640,6 +1655,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1754,6 +1770,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     alt="Blow for rebel clubs as court says Uefa can block Super League"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1850,6 +1867,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     alt="Blow for rebel clubs as court says Uefa can block Super League"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1955,6 +1973,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -2074,6 +2093,7 @@ exports[`Render Lead Story 1 Slice large Article Stack 1`] = `
                     alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -2194,6 +2214,7 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
                 alt="American owners pose threat to English pyramid 2"
                 class="css-ssxt4f"
                 loading="lazy"
+                style="object-fit: cover;"
               />
             </picture>
           </a>
@@ -2279,6 +2300,7 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                 class="css-ssxt4f"
                 loading="lazy"
+                style="object-fit: cover;"
               />
             </picture>
           </a>
@@ -2383,6 +2405,7 @@ exports[`Render Lead Story 1 Slice small Article Stack 1`] = `
                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                 class="css-ssxt4f"
                 loading="lazy"
+                style="object-fit: cover;"
               />
             </picture>
           </a>

--- a/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                     alt="Short title of the card describing the main content"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -457,6 +458,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -620,6 +622,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -715,6 +718,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                           alt="‘American owners pose threat to English pyramid’"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -1005,6 +1009,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1114,6 +1119,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1242,6 +1248,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1328,6 +1335,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1423,6 +1431,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1528,6 +1537,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1642,6 +1652,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1738,6 +1749,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1843,6 +1855,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1962,6 +1975,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -2083,6 +2097,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2192,6 +2207,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2320,6 +2336,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2406,6 +2423,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2501,6 +2519,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2606,6 +2625,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2720,6 +2740,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2816,6 +2837,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2921,6 +2943,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -3040,6 +3063,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -3170,6 +3194,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3279,6 +3304,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3407,6 +3433,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3493,6 +3520,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3588,6 +3616,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3693,6 +3722,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3800,6 +3830,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -3909,6 +3940,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4037,6 +4069,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4123,6 +4156,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4218,6 +4252,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4323,6 +4358,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4435,6 +4471,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4530,6 +4567,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4681,6 +4719,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -4790,6 +4829,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -4918,6 +4958,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5004,6 +5045,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5099,6 +5141,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5204,6 +5247,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5318,6 +5362,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5414,6 +5459,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5519,6 +5565,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5638,6 +5685,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5759,6 +5807,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -5868,6 +5917,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -5996,6 +6046,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6082,6 +6133,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6177,6 +6229,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6282,6 +6335,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6396,6 +6450,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6492,6 +6547,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6597,6 +6653,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6716,6 +6773,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6846,6 +6904,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -6955,6 +7014,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7083,6 +7143,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7169,6 +7230,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7264,6 +7326,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7369,6 +7432,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7476,6 +7540,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -7585,6 +7650,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -7713,6 +7779,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -7799,6 +7866,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -7894,6 +7962,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -7999,6 +8068,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -8111,6 +8181,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -8206,6 +8277,7 @@ exports[`Render Lead Story 1 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -8340,6 +8412,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                     alt="Short title of the card describing the main content"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -8763,6 +8836,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -8926,6 +9000,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -9021,6 +9096,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                           alt="‘American owners pose threat to English pyramid’"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -9311,6 +9387,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9420,6 +9497,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9548,6 +9626,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9634,6 +9713,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9729,6 +9809,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9834,6 +9915,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9948,6 +10030,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -10044,6 +10127,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -10149,6 +10233,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -10268,6 +10353,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -10389,6 +10475,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10498,6 +10585,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10626,6 +10714,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10712,6 +10801,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10807,6 +10897,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10912,6 +11003,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -11026,6 +11118,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -11122,6 +11215,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -11227,6 +11321,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -11346,6 +11441,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -11476,6 +11572,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11585,6 +11682,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11713,6 +11811,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11799,6 +11898,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11894,6 +11994,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11999,6 +12100,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -12106,6 +12208,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12215,6 +12318,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12343,6 +12447,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12429,6 +12534,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12524,6 +12630,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12629,6 +12736,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12741,6 +12849,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12836,6 +12945,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12987,6 +13097,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13096,6 +13207,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13224,6 +13336,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13310,6 +13423,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13405,6 +13519,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13510,6 +13625,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13624,6 +13740,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13720,6 +13837,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13825,6 +13943,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13944,6 +14063,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -14065,6 +14185,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14174,6 +14295,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14302,6 +14424,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14388,6 +14511,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14483,6 +14607,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14588,6 +14713,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14702,6 +14828,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14798,6 +14925,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14903,6 +15031,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -15022,6 +15151,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -15152,6 +15282,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15261,6 +15392,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15389,6 +15521,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15475,6 +15608,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15570,6 +15704,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15675,6 +15810,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15782,6 +15918,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -15891,6 +16028,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -16019,6 +16157,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -16105,6 +16244,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -16200,6 +16340,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -16305,6 +16446,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -16417,6 +16559,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -16512,6 +16655,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when \`articlesWi
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -16646,6 +16790,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     alt="Short title of the card describing the main content"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -17069,6 +17214,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -17232,6 +17378,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -17327,6 +17474,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           alt="‘American owners pose threat to English pyramid’"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -17617,6 +17765,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17726,6 +17875,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17854,6 +18004,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17940,6 +18091,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -18035,6 +18187,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -18140,6 +18293,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -18254,6 +18408,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -18350,6 +18505,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -18455,6 +18611,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -18574,6 +18731,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -18695,6 +18853,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18804,6 +18963,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18932,6 +19092,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19018,6 +19179,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19113,6 +19275,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19218,6 +19381,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19332,6 +19496,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19428,6 +19593,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19533,6 +19699,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19652,6 +19819,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19782,6 +19950,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -19891,6 +20060,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -20019,6 +20189,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -20105,6 +20276,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -20200,6 +20372,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -20305,6 +20478,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -20412,6 +20586,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20521,6 +20696,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20649,6 +20825,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20735,6 +20912,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20830,6 +21008,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20935,6 +21114,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -21047,6 +21227,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -21142,6 +21323,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -21293,6 +21475,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21402,6 +21585,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21530,6 +21714,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21616,6 +21801,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21711,6 +21897,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21816,6 +22003,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21930,6 +22118,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -22026,6 +22215,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -22131,6 +22321,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -22250,6 +22441,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -22371,6 +22563,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22480,6 +22673,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22608,6 +22802,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22694,6 +22889,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22789,6 +22985,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22894,6 +23091,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23008,6 +23206,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23104,6 +23303,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23209,6 +23409,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23328,6 +23529,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23458,6 +23660,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23567,6 +23770,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23695,6 +23899,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23781,6 +23986,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23876,6 +24082,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23981,6 +24188,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -24088,6 +24296,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24197,6 +24406,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24325,6 +24535,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24411,6 +24622,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24506,6 +24718,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24611,6 +24824,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24723,6 +24937,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24818,6 +25033,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24952,6 +25168,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     alt="Short title of the card describing the main content"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -25375,6 +25592,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -25538,6 +25756,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -25633,6 +25852,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           alt="‘American owners pose threat to English pyramid’"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -25923,6 +26143,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26032,6 +26253,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26160,6 +26382,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26246,6 +26469,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26341,6 +26565,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26446,6 +26671,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26560,6 +26786,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26656,6 +26883,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26761,6 +26989,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26880,6 +27109,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -27001,6 +27231,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27110,6 +27341,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27238,6 +27470,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27324,6 +27557,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27419,6 +27653,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27524,6 +27759,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27638,6 +27874,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27734,6 +27971,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27839,6 +28077,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27958,6 +28197,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -28088,6 +28328,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -28197,6 +28438,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -28325,6 +28567,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -28411,6 +28654,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -28506,6 +28750,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -28611,6 +28856,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -28718,6 +28964,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -28827,6 +29074,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -28955,6 +29203,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -29041,6 +29290,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -29136,6 +29386,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -29241,6 +29492,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -29353,6 +29605,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -29448,6 +29701,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -29599,6 +29853,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -29708,6 +29963,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -29836,6 +30092,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -29922,6 +30179,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -30017,6 +30275,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -30122,6 +30381,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -30236,6 +30496,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -30332,6 +30593,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -30437,6 +30699,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -30556,6 +30819,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -30677,6 +30941,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -30786,6 +31051,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -30914,6 +31180,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -31000,6 +31267,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -31095,6 +31363,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -31200,6 +31469,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -31314,6 +31584,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -31410,6 +31681,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -31515,6 +31787,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -31634,6 +31907,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -31764,6 +32038,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -31873,6 +32148,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -32001,6 +32277,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -32087,6 +32364,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -32182,6 +32460,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -32287,6 +32566,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -32394,6 +32674,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32503,6 +32784,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32631,6 +32913,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32717,6 +33000,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32812,6 +33096,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32917,6 +33202,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -33029,6 +33315,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -33124,6 +33411,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -33258,6 +33546,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                     alt="Short title of the card describing the main content"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -33681,6 +33970,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -33844,6 +34134,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia 2"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -33939,6 +34230,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                           alt="‘American owners pose threat to English pyramid’"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -34229,6 +34521,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -34338,6 +34631,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -34466,6 +34760,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -34552,6 +34847,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -34647,6 +34943,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -34752,6 +35049,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -34866,6 +35164,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -34962,6 +35261,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -35067,6 +35367,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -35186,6 +35487,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -35307,6 +35609,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -35416,6 +35719,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -35544,6 +35848,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -35630,6 +35935,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -35725,6 +36031,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -35830,6 +36137,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -35944,6 +36252,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -36040,6 +36349,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -36145,6 +36455,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -36264,6 +36575,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -36394,6 +36706,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -36503,6 +36816,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -36631,6 +36945,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -36717,6 +37032,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -36812,6 +37128,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -36917,6 +37234,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -37024,6 +37342,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -37133,6 +37452,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -37261,6 +37581,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -37347,6 +37668,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -37442,6 +37764,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -37547,6 +37870,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -37659,6 +37983,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -37754,6 +38079,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -37905,6 +38231,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -38014,6 +38341,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -38142,6 +38470,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -38228,6 +38557,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -38323,6 +38653,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -38428,6 +38759,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -38542,6 +38874,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -38638,6 +38971,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -38743,6 +39077,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -38862,6 +39197,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -38983,6 +39319,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -39092,6 +39429,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -39220,6 +39558,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -39306,6 +39645,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -39401,6 +39741,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -39506,6 +39847,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -39620,6 +39962,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -39716,6 +40059,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -39821,6 +40165,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -39940,6 +40285,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -40070,6 +40416,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -40179,6 +40526,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -40307,6 +40655,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -40393,6 +40742,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -40488,6 +40838,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -40593,6 +40944,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -40700,6 +41052,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -40809,6 +41162,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -40937,6 +41291,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -41023,6 +41378,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -41118,6 +41474,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -41223,6 +41580,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -41335,6 +41693,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -41430,6 +41789,7 @@ exports[`Render Lead Story 1 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/article-stacks.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/article-stacks.test.tsx.snap
@@ -298,6 +298,7 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
                       alt="Short title of the card describing the main content 7"
                       class="css-1qgqq71"
                       src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -450,6 +451,7 @@ exports[`Render ArticleStack Slice matches snapshot with default width 1`] = `
                       alt="Short title of the card describing the main content 8"
                       class="css-1qgqq71"
                       src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -858,6 +860,7 @@ exports[`Render ArticleStack renders with passed width 1`] = `
                       alt="Short title of the card describing the main content 7"
                       class="css-1qgqq71"
                       src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -1010,6 +1013,7 @@ exports[`Render ArticleStack renders with passed width 1`] = `
                       alt="Short title of the card describing the main content 8"
                       class="css-1qgqq71"
                       src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>

--- a/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-2/__tests__/__snapshots__/index.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -198,6 +199,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -617,6 +619,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               alt="Short title of the card describing the main content 7"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -769,6 +772,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                               alt="Short title of the card describing the main content 8"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -934,6 +938,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1043,6 +1048,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1171,6 +1177,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1257,6 +1264,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1352,6 +1360,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1457,6 +1466,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1571,6 +1581,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1667,6 +1678,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1772,6 +1784,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1891,6 +1904,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -2012,6 +2026,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2121,6 +2136,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2249,6 +2265,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2335,6 +2352,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2430,6 +2448,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2535,6 +2554,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2649,6 +2669,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2745,6 +2766,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2850,6 +2872,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2969,6 +2992,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -3099,6 +3123,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3208,6 +3233,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3336,6 +3362,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3422,6 +3449,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3517,6 +3545,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3622,6 +3651,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3729,6 +3759,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -3838,6 +3869,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -3966,6 +3998,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4052,6 +4085,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4147,6 +4181,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4252,6 +4287,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4364,6 +4400,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4459,6 +4496,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4610,6 +4648,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -4719,6 +4758,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -4847,6 +4887,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -4933,6 +4974,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5028,6 +5070,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5133,6 +5176,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5247,6 +5291,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5343,6 +5388,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5448,6 +5494,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5567,6 +5614,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5688,6 +5736,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -5797,6 +5846,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -5925,6 +5975,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6011,6 +6062,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6106,6 +6158,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6211,6 +6264,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6325,6 +6379,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6421,6 +6476,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6526,6 +6582,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6645,6 +6702,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6775,6 +6833,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -6884,6 +6943,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7012,6 +7072,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7098,6 +7159,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7193,6 +7255,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7298,6 +7361,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7405,6 +7469,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -7514,6 +7579,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -7642,6 +7708,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -7728,6 +7795,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -7823,6 +7891,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -7928,6 +7997,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -8040,6 +8110,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -8135,6 +8206,7 @@ exports[`Render Lead Story 2 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -8280,6 +8352,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -8433,6 +8506,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -8852,6 +8926,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               alt="Short title of the card describing the main content 7"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -9004,6 +9079,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               alt="Short title of the card describing the main content 8"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -9169,6 +9245,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9278,6 +9355,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9406,6 +9484,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9492,6 +9571,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9587,6 +9667,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9692,6 +9773,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9806,6 +9888,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9902,6 +9985,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -10007,6 +10091,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -10126,6 +10211,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -10247,6 +10333,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10356,6 +10443,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10484,6 +10572,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10570,6 +10659,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10665,6 +10755,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10770,6 +10861,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10884,6 +10976,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10980,6 +11073,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -11085,6 +11179,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -11204,6 +11299,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -11334,6 +11430,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11443,6 +11540,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11571,6 +11669,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11657,6 +11756,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11752,6 +11852,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11857,6 +11958,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11964,6 +12066,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12073,6 +12176,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12201,6 +12305,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12287,6 +12392,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12382,6 +12488,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12487,6 +12594,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12599,6 +12707,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12694,6 +12803,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12845,6 +12955,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -12954,6 +13065,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13082,6 +13194,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13168,6 +13281,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13263,6 +13377,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13368,6 +13483,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13482,6 +13598,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13578,6 +13695,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13683,6 +13801,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13802,6 +13921,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13923,6 +14043,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14032,6 +14153,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14160,6 +14282,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14246,6 +14369,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14341,6 +14465,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14446,6 +14571,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14560,6 +14686,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14656,6 +14783,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14761,6 +14889,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14880,6 +15009,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -15010,6 +15140,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15119,6 +15250,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15247,6 +15379,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15333,6 +15466,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15428,6 +15562,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15533,6 +15668,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15640,6 +15776,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -15749,6 +15886,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -15877,6 +16015,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -15963,6 +16102,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -16058,6 +16198,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -16163,6 +16304,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -16275,6 +16417,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -16370,6 +16513,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -16515,6 +16659,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -16668,6 +16813,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -17087,6 +17233,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               alt="Short title of the card describing the main content 7"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -17239,6 +17386,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               alt="Short title of the card describing the main content 8"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -17404,6 +17552,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17513,6 +17662,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17641,6 +17791,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17727,6 +17878,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17822,6 +17974,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17927,6 +18080,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -18041,6 +18195,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -18137,6 +18292,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -18242,6 +18398,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -18361,6 +18518,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -18482,6 +18640,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18591,6 +18750,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18719,6 +18879,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18805,6 +18966,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18900,6 +19062,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19005,6 +19168,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19119,6 +19283,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19215,6 +19380,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19320,6 +19486,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19439,6 +19606,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19569,6 +19737,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -19678,6 +19847,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -19806,6 +19976,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -19892,6 +20063,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -19987,6 +20159,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -20092,6 +20265,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -20199,6 +20373,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20308,6 +20483,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20436,6 +20612,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20522,6 +20699,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20617,6 +20795,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20722,6 +20901,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20834,6 +21014,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20929,6 +21110,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -21080,6 +21262,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21189,6 +21372,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21317,6 +21501,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21403,6 +21588,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21498,6 +21684,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21603,6 +21790,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21717,6 +21905,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21813,6 +22002,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21918,6 +22108,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -22037,6 +22228,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -22158,6 +22350,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22267,6 +22460,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22395,6 +22589,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22481,6 +22676,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22576,6 +22772,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22681,6 +22878,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22795,6 +22993,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22891,6 +23090,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22996,6 +23196,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23115,6 +23316,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23245,6 +23447,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23354,6 +23557,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23482,6 +23686,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23568,6 +23773,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23663,6 +23869,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23768,6 +23975,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23875,6 +24083,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23984,6 +24193,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24112,6 +24322,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24198,6 +24409,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24293,6 +24505,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24398,6 +24611,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24510,6 +24724,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24605,6 +24820,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24750,6 +24966,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -24903,6 +25120,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                         alt="Sarcacens an inclusive club? They didnt look out for me"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -25322,6 +25540,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               alt="Short title of the card describing the main content 7"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -25474,6 +25693,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                               alt="Short title of the card describing the main content 8"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -25639,6 +25859,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -25748,6 +25969,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -25876,6 +26098,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -25962,6 +26185,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26057,6 +26281,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26162,6 +26387,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26276,6 +26502,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26372,6 +26599,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26477,6 +26705,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26596,6 +26825,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26717,6 +26947,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -26826,6 +27057,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -26954,6 +27186,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27040,6 +27273,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27135,6 +27369,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27240,6 +27475,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27354,6 +27590,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27450,6 +27687,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27555,6 +27793,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27674,6 +27913,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27804,6 +28044,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -27913,6 +28154,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -28041,6 +28283,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -28127,6 +28370,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -28222,6 +28466,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -28327,6 +28572,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -28434,6 +28680,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -28543,6 +28790,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -28671,6 +28919,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -28757,6 +29006,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -28852,6 +29102,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -28957,6 +29208,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -29069,6 +29321,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -29164,6 +29417,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -29315,6 +29569,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -29424,6 +29679,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -29552,6 +29808,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -29638,6 +29895,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -29733,6 +29991,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -29838,6 +30097,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -29952,6 +30212,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -30048,6 +30309,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -30153,6 +30415,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -30272,6 +30535,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -30393,6 +30657,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -30502,6 +30767,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -30630,6 +30896,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -30716,6 +30983,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -30811,6 +31079,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -30916,6 +31185,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -31030,6 +31300,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -31126,6 +31397,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -31231,6 +31503,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -31350,6 +31623,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -31480,6 +31754,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -31589,6 +31864,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -31717,6 +31993,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -31803,6 +32080,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -31898,6 +32176,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -32003,6 +32282,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -32110,6 +32390,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32219,6 +32500,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32347,6 +32629,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32433,6 +32716,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32528,6 +32812,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32633,6 +32918,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32745,6 +33031,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32840,6 +33127,7 @@ exports[`Render Lead Story 2 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>

--- a/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-3/__tests__/__snapshots__/index.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                           alt="Short title of the card describing the main content"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -734,6 +735,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                       alt="Short title of the card describing the main content"
                       class="css-1qgqq71"
                       src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=2050%2C2563%2C1085%2C173&resize=750"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -900,6 +902,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1009,6 +1012,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1137,6 +1141,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1223,6 +1228,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1318,6 +1324,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1423,6 +1430,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1537,6 +1545,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1633,6 +1642,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1738,6 +1748,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1857,6 +1868,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -1978,6 +1990,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2087,6 +2100,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2215,6 +2229,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2301,6 +2316,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2396,6 +2412,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2501,6 +2518,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2615,6 +2633,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2711,6 +2730,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2816,6 +2836,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -2935,6 +2956,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -3065,6 +3087,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3174,6 +3197,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3302,6 +3326,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3388,6 +3413,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3483,6 +3509,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3588,6 +3615,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3695,6 +3723,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -3804,6 +3833,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -3932,6 +3962,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4018,6 +4049,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4113,6 +4145,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4218,6 +4251,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4330,6 +4364,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4425,6 +4460,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4576,6 +4612,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -4685,6 +4722,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -4813,6 +4851,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -4899,6 +4938,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -4994,6 +5034,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5099,6 +5140,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5213,6 +5255,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5309,6 +5352,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5414,6 +5458,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5533,6 +5578,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -5654,6 +5700,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -5763,6 +5810,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -5891,6 +5939,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -5977,6 +6026,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6072,6 +6122,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6177,6 +6228,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6291,6 +6343,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6387,6 +6440,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6492,6 +6546,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6611,6 +6666,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -6741,6 +6797,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -6850,6 +6907,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -6978,6 +7036,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7064,6 +7123,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7159,6 +7219,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7264,6 +7325,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7371,6 +7433,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -7480,6 +7543,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -7608,6 +7672,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -7694,6 +7759,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -7789,6 +7855,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -7894,6 +7961,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -8006,6 +8074,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -8101,6 +8170,7 @@ exports[`Render Lead Story 3 Slice Slice matches snapshot 1`] = `
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -8244,6 +8314,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           alt="Short title of the card describing the main content"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -8935,6 +9006,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       alt="Short title of the card describing the main content"
                       class="css-1qgqq71"
                       src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=2050%2C2563%2C1085%2C173&resize=750"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -9101,6 +9173,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9210,6 +9283,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9338,6 +9412,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9424,6 +9499,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9519,6 +9595,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9624,6 +9701,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9738,6 +9816,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9834,6 +9913,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -9939,6 +10019,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -10058,6 +10139,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -10179,6 +10261,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10288,6 +10371,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10416,6 +10500,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10502,6 +10587,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10597,6 +10683,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10702,6 +10789,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10816,6 +10904,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10912,6 +11001,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -11017,6 +11107,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -11136,6 +11227,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -11266,6 +11358,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11375,6 +11468,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11503,6 +11597,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11589,6 +11684,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11684,6 +11780,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11789,6 +11886,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11896,6 +11994,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12005,6 +12104,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12133,6 +12233,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12219,6 +12320,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12314,6 +12416,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12419,6 +12522,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12531,6 +12635,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12626,6 +12731,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -12777,6 +12883,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -12886,6 +12993,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13014,6 +13122,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13100,6 +13209,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13195,6 +13305,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13300,6 +13411,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13414,6 +13526,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13510,6 +13623,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13615,6 +13729,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13734,6 +13849,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13855,6 +13971,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -13964,6 +14081,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14092,6 +14210,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14178,6 +14297,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14273,6 +14393,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14378,6 +14499,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14492,6 +14614,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14588,6 +14711,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14693,6 +14817,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14812,6 +14937,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14942,6 +15068,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15051,6 +15178,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15179,6 +15307,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15265,6 +15394,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15360,6 +15490,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15465,6 +15596,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -15572,6 +15704,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -15681,6 +15814,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -15809,6 +15943,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -15895,6 +16030,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -15990,6 +16126,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -16095,6 +16232,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -16207,6 +16345,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -16302,6 +16441,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -16445,6 +16585,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           alt="Short title of the card describing the main content"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -17136,6 +17277,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       alt="Short title of the card describing the main content"
                       class="css-1qgqq71"
                       src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=2050%2C2563%2C1085%2C173&resize=750"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -17302,6 +17444,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17411,6 +17554,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17539,6 +17683,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17625,6 +17770,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17720,6 +17866,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17825,6 +17972,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17939,6 +18087,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -18035,6 +18184,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -18140,6 +18290,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -18259,6 +18410,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -18380,6 +18532,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18489,6 +18642,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18617,6 +18771,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18703,6 +18858,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18798,6 +18954,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18903,6 +19060,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19017,6 +19175,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19113,6 +19272,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19218,6 +19378,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19337,6 +19498,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19467,6 +19629,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -19576,6 +19739,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -19704,6 +19868,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -19790,6 +19955,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -19885,6 +20051,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -19990,6 +20157,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -20097,6 +20265,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20206,6 +20375,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20334,6 +20504,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20420,6 +20591,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20515,6 +20687,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20620,6 +20793,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20732,6 +20906,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20827,6 +21002,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -20978,6 +21154,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21087,6 +21264,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21215,6 +21393,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21301,6 +21480,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21396,6 +21576,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21501,6 +21682,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21615,6 +21797,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21711,6 +21894,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21816,6 +22000,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21935,6 +22120,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -22056,6 +22242,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22165,6 +22352,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22293,6 +22481,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22379,6 +22568,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22474,6 +22664,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22579,6 +22770,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22693,6 +22885,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22789,6 +22982,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22894,6 +23088,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23013,6 +23208,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23143,6 +23339,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23252,6 +23449,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23380,6 +23578,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23466,6 +23665,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23561,6 +23761,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23666,6 +23867,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -23773,6 +23975,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23882,6 +24085,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24010,6 +24214,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24096,6 +24301,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24191,6 +24397,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24296,6 +24503,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24408,6 +24616,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24503,6 +24712,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -24646,6 +24856,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           alt="Short title of the card describing the main content"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -25337,6 +25548,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       alt="Short title of the card describing the main content"
                       class="css-1qgqq71"
                       src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=2050%2C2563%2C1085%2C173&resize=750"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -25503,6 +25715,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -25612,6 +25825,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -25740,6 +25954,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -25826,6 +26041,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -25921,6 +26137,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26026,6 +26243,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26140,6 +26358,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26236,6 +26455,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26341,6 +26561,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26460,6 +26681,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -26581,6 +26803,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -26690,6 +26913,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -26818,6 +27042,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -26904,6 +27129,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -26999,6 +27225,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27104,6 +27331,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27218,6 +27446,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27314,6 +27543,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27419,6 +27649,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27538,6 +27769,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -27668,6 +27900,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -27777,6 +28010,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -27905,6 +28139,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -27991,6 +28226,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -28086,6 +28322,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -28191,6 +28428,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -28298,6 +28536,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -28407,6 +28646,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -28535,6 +28775,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -28621,6 +28862,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -28716,6 +28958,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -28821,6 +29064,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -28933,6 +29177,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -29028,6 +29273,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -29179,6 +29425,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -29288,6 +29535,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -29416,6 +29664,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -29502,6 +29751,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -29597,6 +29847,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -29702,6 +29953,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -29816,6 +30068,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -29912,6 +30165,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -30017,6 +30271,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -30136,6 +30391,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -30257,6 +30513,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -30366,6 +30623,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -30494,6 +30752,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -30580,6 +30839,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -30675,6 +30935,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -30780,6 +31041,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -30894,6 +31156,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -30990,6 +31253,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -31095,6 +31359,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -31214,6 +31479,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -31344,6 +31610,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -31453,6 +31720,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -31581,6 +31849,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -31667,6 +31936,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -31762,6 +32032,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -31867,6 +32138,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -31974,6 +32246,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32083,6 +32356,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32211,6 +32485,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32297,6 +32572,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32392,6 +32668,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32497,6 +32774,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32609,6 +32887,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32704,6 +32983,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -32847,6 +33127,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                           alt="Short title of the card describing the main content"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -33538,6 +33819,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                       alt="Short title of the card describing the main content"
                       class="css-1qgqq71"
                       src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=2050%2C2563%2C1085%2C173&resize=750"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -33704,6 +33986,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -33813,6 +34096,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -33941,6 +34225,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -34027,6 +34312,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -34122,6 +34408,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -34227,6 +34514,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -34341,6 +34629,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -34437,6 +34726,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -34542,6 +34832,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -34661,6 +34952,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -34782,6 +35074,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -34891,6 +35184,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -35019,6 +35313,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -35105,6 +35400,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -35200,6 +35496,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -35305,6 +35602,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -35419,6 +35717,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -35515,6 +35814,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -35620,6 +35920,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -35739,6 +36040,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -35869,6 +36171,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -35978,6 +36281,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -36106,6 +36410,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -36192,6 +36497,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -36287,6 +36593,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -36392,6 +36699,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -36499,6 +36807,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -36608,6 +36917,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -36736,6 +37046,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -36822,6 +37133,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -36917,6 +37229,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -37022,6 +37335,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -37134,6 +37448,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -37229,6 +37544,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -37380,6 +37696,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -37489,6 +37806,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -37617,6 +37935,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -37703,6 +38022,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -37798,6 +38118,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -37903,6 +38224,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -38017,6 +38339,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -38113,6 +38436,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -38218,6 +38542,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -38337,6 +38662,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -38458,6 +38784,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -38567,6 +38894,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -38695,6 +39023,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -38781,6 +39110,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -38876,6 +39206,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -38981,6 +39312,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -39095,6 +39427,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -39191,6 +39524,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -39296,6 +39630,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -39415,6 +39750,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -39545,6 +39881,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -39654,6 +39991,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -39782,6 +40120,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -39868,6 +40207,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="American owners pose threat to English pyramid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -39963,6 +40303,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -40068,6 +40409,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                                 alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -40175,6 +40517,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -40284,6 +40627,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -40412,6 +40756,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -40498,6 +40843,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -40593,6 +40939,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -40698,6 +41045,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="£60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -40810,6 +41158,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -40905,6 +41254,7 @@ exports[`Render Lead Story 3 Slice modifies articles correctly when breakpointKe
                             alt="Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>

--- a/packages/ts-newskit/src/slices/lead-story-4/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/lead-story-4/__tests__/__snapshots__/index.test.tsx.snap
@@ -40,6 +40,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         alt="1 Short title of the card describing the main content"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -189,6 +190,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             alt="2 European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -304,6 +306,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             alt="3 American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -395,6 +398,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             alt="2 European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -500,6 +504,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             alt="3 American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -582,6 +587,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             alt="4 £60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -683,6 +689,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -787,6 +794,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                       alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -897,6 +905,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                       alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -1007,6 +1016,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                       alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -1117,6 +1127,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                       alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -1232,6 +1243,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                       alt="4 £60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -1329,6 +1341,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                       alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -1417,6 +1430,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                       alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -1546,6 +1560,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -1671,6 +1686,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -1796,6 +1812,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -1926,6 +1943,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                         alt="1 Short title of the card describing the main content"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -2076,6 +2094,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           alt="2 European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -2201,6 +2220,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           alt="3 American owners pose threat to English pyramid"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -2293,6 +2313,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                           alt="4 £60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -2422,6 +2443,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                                 alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -2508,6 +2530,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                                 alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -2613,6 +2636,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                                 alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -2732,6 +2756,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                                 alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -2860,6 +2885,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                                 alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -2979,6 +3005,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                                 alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3107,6 +3134,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                                 alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3226,6 +3254,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                                 alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3354,6 +3383,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                                 alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3473,6 +3503,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                                 alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -3594,6 +3625,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -3680,6 +3712,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -3785,6 +3818,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -3904,6 +3938,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4032,6 +4067,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4151,6 +4187,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4279,6 +4316,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4398,6 +4436,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4526,6 +4565,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4645,6 +4685,7 @@ exports[`Render Lead Story 4 Slice Slice matches snapshot 1`] = `
                             alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -4785,6 +4826,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="1 Short title of the card describing the main content"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -4934,6 +4976,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="2 European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -5049,6 +5092,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="3 American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -5140,6 +5184,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="2 European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -5245,6 +5290,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="3 American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -5327,6 +5373,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="4 £60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -5428,6 +5475,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -5532,6 +5580,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -5642,6 +5691,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -5752,6 +5802,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -5862,6 +5913,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -5977,6 +6029,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="4 £60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -6074,6 +6127,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -6162,6 +6216,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -6291,6 +6346,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -6416,6 +6472,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -6541,6 +6598,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -6671,6 +6729,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="1 Short title of the card describing the main content"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -6821,6 +6880,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           alt="2 European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -6946,6 +7006,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           alt="3 American owners pose threat to English pyramid"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -7038,6 +7099,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           alt="4 £60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -7167,6 +7229,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7253,6 +7316,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7358,6 +7422,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7477,6 +7542,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7605,6 +7671,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7724,6 +7791,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7852,6 +7920,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -7971,6 +8040,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -8099,6 +8169,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -8218,6 +8289,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -8339,6 +8411,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -8425,6 +8498,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -8530,6 +8604,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -8649,6 +8724,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -8777,6 +8853,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -8896,6 +8973,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -9024,6 +9102,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -9143,6 +9222,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -9271,6 +9351,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -9390,6 +9471,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -9530,6 +9612,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="1 Short title of the card describing the main content"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -9679,6 +9762,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="2 European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -9794,6 +9878,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="3 American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -9885,6 +9970,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="2 European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -9990,6 +10076,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="3 American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10072,6 +10159,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="4 £60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10173,6 +10261,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -10277,6 +10366,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -10387,6 +10477,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -10497,6 +10588,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -10607,6 +10699,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -10722,6 +10815,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="4 £60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -10819,6 +10913,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -10907,6 +11002,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -11036,6 +11132,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -11161,6 +11258,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -11286,6 +11384,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -11416,6 +11515,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="1 Short title of the card describing the main content"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -11566,6 +11666,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           alt="2 European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -11691,6 +11792,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           alt="3 American owners pose threat to English pyramid"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -11783,6 +11885,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           alt="4 £60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -11912,6 +12015,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -11998,6 +12102,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -12103,6 +12208,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -12222,6 +12328,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -12350,6 +12457,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -12469,6 +12577,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -12597,6 +12706,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -12716,6 +12826,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -12844,6 +12955,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -12963,6 +13075,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -13084,6 +13197,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -13170,6 +13284,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -13275,6 +13390,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -13394,6 +13510,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -13522,6 +13639,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -13641,6 +13759,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -13769,6 +13888,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -13888,6 +14008,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14016,6 +14137,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14135,6 +14257,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14275,6 +14398,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="1 Short title of the card describing the main content"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -14424,6 +14548,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="2 European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14539,6 +14664,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="3 American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14630,6 +14756,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="2 European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14735,6 +14862,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="3 American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14817,6 +14945,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="4 £60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -14918,6 +15047,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -15022,6 +15152,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -15132,6 +15263,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -15242,6 +15374,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -15352,6 +15485,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -15467,6 +15601,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="4 £60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -15564,6 +15699,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -15652,6 +15788,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -15781,6 +15918,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -15906,6 +16044,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -16031,6 +16170,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -16161,6 +16301,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="1 Short title of the card describing the main content"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -16311,6 +16452,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           alt="2 European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -16436,6 +16578,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           alt="3 American owners pose threat to English pyramid"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -16528,6 +16671,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           alt="4 £60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -16657,6 +16801,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -16743,6 +16888,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -16848,6 +16994,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -16967,6 +17114,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17095,6 +17243,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17214,6 +17363,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17342,6 +17492,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17461,6 +17612,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17589,6 +17741,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17708,6 +17861,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -17829,6 +17983,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -17915,6 +18070,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18020,6 +18176,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18139,6 +18296,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18267,6 +18425,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18386,6 +18545,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18514,6 +18674,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18633,6 +18794,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18761,6 +18923,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -18880,6 +19043,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19020,6 +19184,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="1 Short title of the card describing the main content"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -19169,6 +19334,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="2 European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19284,6 +19450,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="3 American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19375,6 +19542,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="2 European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19480,6 +19648,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="3 American owners pose threat to English pyramid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19562,6 +19731,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="4 £60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19663,6 +19833,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -19767,6 +19938,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -19877,6 +20049,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -19987,6 +20160,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -20097,6 +20271,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -20212,6 +20387,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="4 £60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -20309,6 +20485,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -20397,6 +20574,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                       alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -20526,6 +20704,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -20651,6 +20830,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -20776,6 +20956,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -20906,6 +21087,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                         alt="1 Short title of the card describing the main content"
                         class="css-1qgqq71"
                         src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -21056,6 +21238,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           alt="2 European cup winner Mihajlovic dies aged 53 after battle with leukaemia"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -21181,6 +21364,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           alt="3 American owners pose threat to English pyramid"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -21273,6 +21457,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                           alt="4 £60m Brazilian prodigy Endrick snubs Chelsea to join Real Madrid"
                           class="css-ssxt4f"
                           loading="lazy"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -21402,6 +21587,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21488,6 +21674,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21593,6 +21780,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21712,6 +21900,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21840,6 +22029,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -21959,6 +22149,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -22087,6 +22278,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -22206,6 +22398,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -22334,6 +22527,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -22453,6 +22647,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                                 alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                                 class="css-ssxt4f"
                                 loading="lazy"
+                                style="object-fit: cover;"
                               />
                             </picture>
                           </a>
@@ -22574,6 +22769,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22660,6 +22856,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="5 Blow for rebel clubs as court says Uefa can block Super League"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22765,6 +22962,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -22884,6 +23082,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="6 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23012,6 +23211,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23131,6 +23331,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="7 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23259,6 +23460,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23378,6 +23580,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="8 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23506,6 +23709,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>
@@ -23625,6 +23829,7 @@ exports[`Render Lead Story 4 Slice modifies articles correctly when breakpointKe
                             alt="9 Blow for rebel clubs as court says Uefa can block Super League 2"
                             class="css-ssxt4f"
                             loading="lazy"
+                            style="object-fit: cover;"
                           />
                         </picture>
                       </a>

--- a/packages/ts-newskit/src/slices/list-view-slice/__tests__/__snapshots__/desktop.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/list-view-slice/__tests__/__snapshots__/desktop.test.tsx.snap
@@ -52,6 +52,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                           alt="1 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -240,6 +241,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                           alt="2 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -428,6 +430,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                           alt="3 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -616,6 +619,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                           alt="4 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -794,6 +798,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                           alt="5 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -968,6 +973,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                           alt="6 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -1156,6 +1162,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                           alt="7 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -1292,6 +1299,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                           alt="8 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -1466,6 +1474,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                           alt="9 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -1621,6 +1630,7 @@ exports[`Render ListViewSliceDesktop matches snapshot 1`] = `
                           alt="10 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>

--- a/packages/ts-newskit/src/slices/list-view-slice/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/list-view-slice/__tests__/__snapshots__/index.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                               alt="1 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -260,6 +261,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                               alt="2 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -462,6 +464,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                               alt="3 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -664,6 +667,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                               alt="4 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -856,6 +860,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                               alt="5 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -1030,6 +1035,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                               alt="6 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -1232,6 +1238,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                               alt="7 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -1368,6 +1375,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                               alt="8 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -1556,6 +1564,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                               alt="9 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -1725,6 +1734,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                               alt="10 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -2006,6 +2016,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                           alt="1 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -2187,6 +2198,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                           alt="2 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -2368,6 +2380,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                           alt="3 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -2549,6 +2562,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                           alt="4 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -2730,6 +2744,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                           alt="5 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -2868,6 +2883,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                           alt="6 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -3049,6 +3065,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                           alt="7 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -3174,6 +3191,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                           alt="8 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -3341,6 +3359,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                           alt="9 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -3499,6 +3518,7 @@ exports[`Render List View Slice Slice matches snapshot 1`] = `
                           alt="10 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -3683,6 +3703,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="1 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -3885,6 +3906,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="2 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -4087,6 +4109,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="3 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -4289,6 +4312,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="4 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -4481,6 +4505,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="5 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -4655,6 +4680,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="6 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -4857,6 +4883,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="7 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -4993,6 +5020,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="8 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -5181,6 +5209,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="9 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -5350,6 +5379,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="10 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -5631,6 +5661,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="1 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -5812,6 +5843,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="2 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -5993,6 +6025,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="3 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -6174,6 +6207,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="4 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -6355,6 +6389,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="5 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -6493,6 +6528,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="6 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -6674,6 +6710,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="7 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -6799,6 +6836,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="8 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -6966,6 +7004,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="9 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -7124,6 +7163,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="10 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -7308,6 +7348,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="1 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -7510,6 +7551,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="2 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -7712,6 +7754,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="3 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -7914,6 +7957,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="4 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -8106,6 +8150,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="5 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -8280,6 +8325,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="6 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -8482,6 +8528,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="7 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -8618,6 +8665,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="8 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -8806,6 +8854,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="9 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -8975,6 +9024,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="10 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -9256,6 +9306,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="1 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -9437,6 +9488,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="2 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -9618,6 +9670,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="3 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -9799,6 +9852,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="4 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -9980,6 +10034,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="5 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -10118,6 +10173,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="6 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -10299,6 +10355,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="7 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -10424,6 +10481,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="8 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -10591,6 +10649,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="9 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -10749,6 +10808,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="10 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -10933,6 +10993,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="1 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -11135,6 +11196,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="2 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -11337,6 +11399,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="3 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -11539,6 +11602,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="4 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -11731,6 +11795,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="5 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -11905,6 +11970,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="6 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -12107,6 +12173,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="7 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -12243,6 +12310,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="8 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -12431,6 +12499,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="9 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -12600,6 +12669,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="10 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -12881,6 +12951,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="1 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -13062,6 +13133,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="2 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -13243,6 +13315,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="3 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -13424,6 +13497,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="4 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -13605,6 +13679,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="5 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -13743,6 +13818,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="6 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -13924,6 +14000,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="7 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -14049,6 +14126,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="8 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -14216,6 +14294,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="9 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -14374,6 +14453,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="10 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -14558,6 +14638,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="1 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -14760,6 +14841,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="2 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -14962,6 +15044,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="3 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -15164,6 +15247,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="4 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -15356,6 +15440,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="5 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -15530,6 +15615,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="6 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -15732,6 +15818,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="7 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -15868,6 +15955,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="8 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -16056,6 +16144,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="9 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -16225,6 +16314,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                               alt="10 Sarcacens an inclusive club? They didnt look out for me"
                               class="css-1qgqq71"
                               src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                              style="object-fit: cover;"
                             />
                           </picture>
                         </a>
@@ -16506,6 +16596,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="1 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -16687,6 +16778,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="2 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -16868,6 +16960,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="3 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -17049,6 +17142,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="4 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -17230,6 +17324,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="5 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -17368,6 +17463,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="6 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -17549,6 +17645,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="7 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -17674,6 +17771,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="8 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -17841,6 +17939,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="9 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>
@@ -17999,6 +18098,7 @@ exports[`Render List View Slice modifies articles correctly when breakpointKey i
                           alt="10 Sarcacens an inclusive club? They didnt look out for me"
                           class="css-1qgqq71"
                           src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                          style="object-fit: cover;"
                         />
                       </picture>
                     </a>

--- a/packages/ts-newskit/src/slices/list-view-slice/__tests__/__snapshots__/mobile.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/list-view-slice/__tests__/__snapshots__/mobile.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                     alt="1 Sarcacens an inclusive club? They didnt look out for me"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -206,6 +207,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                     alt="2 Sarcacens an inclusive club? They didnt look out for me"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -373,6 +375,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                     alt="3 Sarcacens an inclusive club? They didnt look out for me"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -540,6 +543,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                     alt="4 Sarcacens an inclusive club? They didnt look out for me"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -707,6 +711,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                     alt="5 Sarcacens an inclusive club? They didnt look out for me"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -845,6 +850,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                     alt="6 Sarcacens an inclusive club? They didnt look out for me"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1012,6 +1018,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                     alt="7 Sarcacens an inclusive club? They didnt look out for me"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1137,6 +1144,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                     alt="8 Sarcacens an inclusive club? They didnt look out for me"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1290,6 +1298,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                     alt="9 Sarcacens an inclusive club? They didnt look out for me"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1434,6 +1443,7 @@ exports[`Render ListViewSliceMobile matches snapshot 1`] = `
                     alt="10 Sarcacens an inclusive club? They didnt look out for me"
                     class="css-1qgqq71"
                     src="https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fbde50bea-247f-11ee-8c1b-d5d52b458fbd.jpg?crop=3844%2C2563%2C188%2C173&resize=750"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>

--- a/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
@@ -99,6 +99,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                         alt="Short title of the card describing the main content 9"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -380,6 +381,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                         alt="Short title of the card describing the main content 12"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -661,6 +663,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                         alt="Short title of the card describing the main content 15"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -942,6 +945,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                         alt="Short title of the card describing the main content 18"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -1237,6 +1241,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                       alt="Short title of the card describing the main content 9"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -1518,6 +1523,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                       alt="Short title of the card describing the main content 12"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -1799,6 +1805,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                       alt="Short title of the card describing the main content 15"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -2080,6 +2087,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
                       alt="Short title of the card describing the main content 18"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -2387,6 +2395,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                         alt="Short title of the card describing the main content 9"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -2668,6 +2677,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                         alt="Short title of the card describing the main content 12"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -2949,6 +2959,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                         alt="Short title of the card describing the main content 15"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -3230,6 +3241,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                         alt="Short title of the card describing the main content 18"
                         class="css-ssxt4f"
                         loading="lazy"
+                        style="object-fit: cover;"
                       />
                     </picture>
                   </a>
@@ -3525,6 +3537,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                       alt="Short title of the card describing the main content 9"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -3806,6 +3819,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                       alt="Short title of the card describing the main content 12"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -4087,6 +4101,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                       alt="Short title of the card describing the main content 15"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>
@@ -4368,6 +4383,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
                       alt="Short title of the card describing the main content 18"
                       class="css-ssxt4f"
                       loading="lazy"
+                      style="object-fit: cover;"
                     />
                   </picture>
                 </a>

--- a/packages/ts-newskit/src/slices/stacked-module-1/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/stacked-module-1/__tests__/__snapshots__/index.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                     alt="Short title of the card describing the main content"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -156,6 +157,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                     alt="Short title of the card describing the main content 2"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -281,6 +283,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                     alt="Short title of the card describing the main content 3"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -392,6 +395,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                     alt="Short title of the card describing the main content 4"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -524,6 +528,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                     alt="Short title of the card describing the main content 5"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -635,6 +640,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                     alt="Short title of the card describing the main content 6"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -760,6 +766,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                     alt="Short title of the card describing the main content 7"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -871,6 +878,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot 1`] = `
                     alt="Short title of the card describing the main content 8"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1012,6 +1020,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                     alt="Short title of the card describing the main content"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1123,6 +1132,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                     alt="Short title of the card describing the main content 2"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1248,6 +1258,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                     alt="Short title of the card describing the main content 3"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1359,6 +1370,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                     alt="Short title of the card describing the main content 4"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1491,6 +1503,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                     alt="Short title of the card describing the main content 5"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1602,6 +1615,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                     alt="Short title of the card describing the main content 6"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1727,6 +1741,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                     alt="Short title of the card describing the main content 7"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1838,6 +1853,7 @@ exports[`Render StackModule 1 Slice Slice matches snapshot for \`null\` breakpoi
                     alt="Short title of the card describing the main content 8"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -1979,6 +1995,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -2090,6 +2107,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 2"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -2215,6 +2233,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 3"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -2326,6 +2345,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 4"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -2458,6 +2478,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 5"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -2569,6 +2590,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 6"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -2694,6 +2716,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 7"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -2805,6 +2828,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 8"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -2946,6 +2970,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -3057,6 +3082,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 2"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -3182,6 +3208,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 3"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -3293,6 +3320,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 4"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -3425,6 +3453,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 5"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -3536,6 +3565,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 6"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -3661,6 +3691,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 7"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -3772,6 +3803,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 8"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -3913,6 +3945,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -4024,6 +4057,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 2"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -4149,6 +4183,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 3"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -4260,6 +4295,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 4"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -4392,6 +4428,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 5"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -4503,6 +4540,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 6"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -4628,6 +4666,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 7"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>
@@ -4739,6 +4778,7 @@ exports[`Render StackModule 1 Slice modifies articles correctly when breakpointK
                     alt="Short title of the card describing the main content 8"
                     class="css-ssxt4f"
                     loading="lazy"
+                    style="object-fit: cover;"
                   />
                 </picture>
               </a>


### PR DESCRIPTION
### Description
- fixed slightly narrowed External content images

**Before:**
![Screenshot 2024-02-05 at 09 21 04](https://github.com/newsuk/times-components/assets/103412329/61e0c2e2-dbb7-4bf5-b5b1-a3b8e32f240b)


**After:**
![Screenshot 2024-02-05 at 09 21 42](https://github.com/newsuk/times-components/assets/103412329/75ea964e-f97e-4ef4-832b-89954ca28fa5)


[TNLBT-1219](https://nidigitalsolutions.jira.com/browse/TNLBT-1219?atlOrigin=eyJpIjoiM2IxMjNiMTdhMzI5NGNjMTkxN2M2ZjU2N2E0Yjc0YTAiLCJwIjoiaiJ9)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.


[TNLBT-1219]: https://nidigitalsolutions.jira.com/browse/TNLBT-1219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ