### PR TITLE
feat(TMRX-1927): add prop to remove divider on slice header

### DIFF
--- a/packages/ts-newskit/src/components/slices/slice-header/SliceHeader.stories.mdx
+++ b/packages/ts-newskit/src/components/slices/slice-header/SliceHeader.stories.mdx
@@ -24,7 +24,7 @@ This takes in a series of props, as below, to display title and href.
 ## View Component
 Please click the 'Canvas' tab for a better viewing experience, where you can update the props and review at the different breakpoints by clicking the preview icon and selecting from our list of pre-defined breakpoints (XS, SM, MD, LG and XL).
 
-export const HeaderStory = ({ title , href, tagline }) => (
+export const HeaderStory = ({ title , href, tagline, showDivider }) => (
   <NewsKitProvider theme={TimesWebLightTheme}>
   <TrackingContextProvider
       analyticsStream={action('analytics-action')}
@@ -34,11 +34,11 @@ export const HeaderStory = ({ title , href, tagline }) => (
         }
       }}
     >
-    <SliceHeader {...{ title,href,tagline }} />
+    <SliceHeader {...{ title,href,tagline, showDivider }} />
     </TrackingContextProvider>
   </NewsKitProvider>
 );
 
-<Story name="SliceHeader" args={{ title: 'Rugby Union', href : '/', tagline: 'The definitive Good University Guide from The Times and Sunday Times provides you with everything you need to know' }}>
+<Story name="SliceHeader" args={{ title: 'Rugby Union', href : '/', tagline: 'The definitive Good University Guide from The Times and Sunday Times provides you with everything you need to know', showDivider: true }}>
   {HeaderStory.bind({})}
 </Story>

--- a/packages/ts-newskit/src/components/slices/slice-header/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/slices/slice-header/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Render Header should render a snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="css-eqx1ec"
+    class="css-i76bho"
   >
     <a
       class="css-1pyvojw"
@@ -68,7 +68,7 @@ exports[`Render Header should render a snapshot 1`] = `
 exports[`Render Header should render a snapshot with tagline 1`] = `
 <DocumentFragment>
   <div
-    class="css-eqx1ec"
+    class="css-i76bho"
   >
     <a
       class="css-1pyvojw"

--- a/packages/ts-newskit/src/components/slices/slice-header/__tests__/index.test.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/__tests__/index.test.tsx
@@ -85,4 +85,14 @@ describe('Render Header', () => {
     );
     expect(queryByRole('link')).toBeFalsy();
   });
+  it('does not render the divider if showDivider is false', () => {
+    const { baseElement } = render(
+      <SliceHeader
+        title="Rugby Union"
+        sliceHeaderClickHandler={mockSliceHeaderClickHandler}
+        showDivider={false}
+      />
+    );
+    expect(baseElement).toHaveStyle({ border: 'none' });
+  });
 });

--- a/packages/ts-newskit/src/components/slices/slice-header/index.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/index.tsx
@@ -27,6 +27,7 @@ export interface SliceHeaderProps {
   iconSize?: MQ<string>;
   padding?: string;
   sliceHeaderClickHandler: (title: string) => void;
+  showDivider?: boolean;
 }
 
 const SliceHeaderLinkWrapper = ({
@@ -59,10 +60,12 @@ export const SliceHeader = ({
   iconArrowSize = { xs: 'iconSize010', md: 'iconSize020' },
   iconSize = { xs: 'sizing060', md: 'sizing080' },
   padding = 'space030',
-  sliceHeaderClickHandler
+  sliceHeaderClickHandler,
+  showDivider = true
 }: SliceHeaderProps) => {
   return (
     <SliceHeaderWrapper
+      showDivider={showDivider}
       stylePreset={{
         xs: 'sliceHeaderPresetMobile',
         md: 'sliceHeaderPresetDesktop'

--- a/packages/ts-newskit/src/components/slices/slice-header/styles.tsx
+++ b/packages/ts-newskit/src/components/slices/slice-header/styles.tsx
@@ -15,7 +15,9 @@ import {
   IconButton
 } from 'newskit';
 
-export const SliceHeaderWrapper = styled(Block)`
+export const SliceHeaderWrapper = styled(Block)<{ showDivider?: boolean }>`
+  ${({ showDivider }) => !showDivider && 'border: none !important'};
+
   & a:hover {
     cursor: pointer;
 

--- a/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/slices/section-bucket/__tests__/__snapshots__/index.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
               data-testid="article-block"
             >
               <div
-                class="css-eqx1ec"
+                class="css-i76bho"
               >
                 <a
                   class="css-1pyvojw"
@@ -306,7 +306,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
               data-testid="article-block"
             >
               <div
-                class="css-eqx1ec"
+                class="css-i76bho"
               >
                 <a
                   class="css-1pyvojw"
@@ -588,7 +588,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
               data-testid="article-block"
             >
               <div
-                class="css-eqx1ec"
+                class="css-i76bho"
               >
                 <a
                   class="css-1pyvojw"
@@ -870,7 +870,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
               data-testid="article-block"
             >
               <div
-                class="css-eqx1ec"
+                class="css-i76bho"
               >
                 <a
                   class="css-1pyvojw"
@@ -1166,7 +1166,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             data-testid="article-block"
           >
             <div
-              class="css-eqx1ec"
+              class="css-i76bho"
             >
               <a
                 class="css-1pyvojw"
@@ -1448,7 +1448,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             data-testid="article-block"
           >
             <div
-              class="css-eqx1ec"
+              class="css-i76bho"
             >
               <a
                 class="css-1pyvojw"
@@ -1730,7 +1730,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             data-testid="article-block"
           >
             <div
-              class="css-eqx1ec"
+              class="css-i76bho"
             >
               <a
                 class="css-1pyvojw"
@@ -2012,7 +2012,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with sm 1`] = `
             data-testid="article-block"
           >
             <div
-              class="css-eqx1ec"
+              class="css-i76bho"
             >
               <a
                 class="css-1pyvojw"
@@ -2320,7 +2320,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
               data-testid="article-block"
             >
               <div
-                class="css-eqx1ec"
+                class="css-i76bho"
               >
                 <a
                   class="css-1pyvojw"
@@ -2602,7 +2602,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
               data-testid="article-block"
             >
               <div
-                class="css-eqx1ec"
+                class="css-i76bho"
               >
                 <a
                   class="css-1pyvojw"
@@ -2884,7 +2884,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
               data-testid="article-block"
             >
               <div
-                class="css-eqx1ec"
+                class="css-i76bho"
               >
                 <a
                   class="css-1pyvojw"
@@ -3166,7 +3166,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
               data-testid="article-block"
             >
               <div
-                class="css-eqx1ec"
+                class="css-i76bho"
               >
                 <a
                   class="css-1pyvojw"
@@ -3462,7 +3462,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
             data-testid="article-block"
           >
             <div
-              class="css-eqx1ec"
+              class="css-i76bho"
             >
               <a
                 class="css-1pyvojw"
@@ -3744,7 +3744,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
             data-testid="article-block"
           >
             <div
-              class="css-eqx1ec"
+              class="css-i76bho"
             >
               <a
                 class="css-1pyvojw"
@@ -4026,7 +4026,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
             data-testid="article-block"
           >
             <div
-              class="css-eqx1ec"
+              class="css-i76bho"
             >
               <a
                 class="css-1pyvojw"
@@ -4308,7 +4308,7 @@ exports[`Render SectionBucket Slice Slice matches snapshot with xl 1`] = `
             data-testid="article-block"
           >
             <div
-              class="css-eqx1ec"
+              class="css-i76bho"
             >
               <a
                 class="css-1pyvojw"


### PR DESCRIPTION
### Description

Adds an optional `showDivider` prop to allow the top divider to be removed.

[JIRA-1927](https://nidigitalsolutions.jira.com/browse/TMRX-1927)


### Checklist

- [X] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots:

**Before**
![Screenshot 2024-02-15 at 12 22 37](https://github.com/newsuk/times-components/assets/142982056/38639b08-28b3-4bc7-9617-65ae3a51e769)

**After**
![Screenshot 2024-02-15 at 12 22 31](https://github.com/newsuk/times-components/assets/142982056/68450a19-9c23-42b0-a20e-3011019ee1f0)

