### PR TITLE
feat(TMRX-1962): Update ad placement in articles

### DIFF
--- a/packages/ad/src/ad.js
+++ b/packages/ad/src/ad.js
@@ -23,7 +23,6 @@ class Ad extends Component {
     };
   }
 
-
   constructor(props) {
     super(props);
 

--- a/packages/ad/src/ad.js
+++ b/packages/ad/src/ad.js
@@ -23,6 +23,7 @@ class Ad extends Component {
     };
   }
 
+
   constructor(props) {
     super(props);
 

--- a/packages/article-skeleton/__tests__/web/inline-ad.test.js
+++ b/packages/article-skeleton/__tests__/web/inline-ad.test.js
@@ -8,7 +8,7 @@ const {
 } = inlineAdFixture;
 
 describe("inline-ad", () => {
-  it("it adds the inline ad block after the 13th paragraph", () => {
+  it("it adds the inline ad block after the 15th paragraph", () => {
     expect(insertInlineAd(contentWithOutAd)).toStrictEqual(contentWithAd);
   });
 

--- a/packages/article-skeleton/fixtures/inline-ad.js
+++ b/packages/article-skeleton/fixtures/inline-ad.js
@@ -196,20 +196,20 @@ const contentWithAd = [
         children: []
       },
       {
-        // 13th para
+        name: "paragraph",
+        children: []
+      },
+      {
+        name: "paragraph",
+        children: []
+      },
+      // 15th para
+      {
         name: "paragraph",
         children: []
       },
       {
         name: "inlineAd1",
-        children: []
-      },
-      {
-        name: "paragraph",
-        children: []
-      },
-      {
-        name: "paragraph",
         children: []
       },
       {

--- a/packages/article-skeleton/src/contentModifiers/inline-ad.js
+++ b/packages/article-skeleton/src/contentModifiers/inline-ad.js
@@ -11,7 +11,7 @@ const insertInlineAd = children => {
   const paywallParagraphs = paywallChildren
     .map((item, index) => ({ ...item, index }))
     .filter(item => item.name === "paragraph");
-  const paraPostition = [13, 20, 27];
+  const paraPostition = [15, 20, 25];
 
   paraPostition.forEach((item, i) => {
     const inlineAd = paywallChildren.find(ad => ad.name === `inlineAd${i + 1}`);
@@ -28,7 +28,6 @@ const insertInlineAd = children => {
       }
     }
   });
-
   return clonedChildren;
 };
 

--- a/packages/article-skeleton/src/contentModifiers/native-ad.js
+++ b/packages/article-skeleton/src/contentModifiers/native-ad.js
@@ -17,7 +17,7 @@ const insertNativeAd = children => {
     return clonedChildren;
   }
 
-  const paragraphCount = Number(9 - paragraph.length);
+  const paragraphCount = Number(10 - paragraph.length);
   const paywallChildren = child.children;
   const paragraphItems = paywallChildren
     .map((item, index) => ({ ...item, index }))


### PR DESCRIPTION
### Description

We have been asked to update our ad placements in articles to display after 5, 10, 15, 20 & 25 paragraphs instead of the current 5, 9, 13, 20, 27. 

[TMRX-1962](https://nidigitalsolutions.jira.com/browse/TMRX-1962)

Have made a [comparison document](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/4751425645/Ad+placement+change+-+5+10+15+20+25) to show the difference across a few different articles.


### Checklist

- [x] Have you done any manual testing?
- [x] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?





[TMRX-1962]: https://nidigitalsolutions.jira.com/browse/TMRX-1962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ