### PR TITLE
feat(TMPZ-000) : Article Sidebar placeholder changes

### DIFF
--- a/packages/ts-newskit/src/components/puzzles/article-sidebar/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/article-sidebar/__tests__/__snapshots__/index.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`ArticleSidebar should render ArticleSidebar component 1`] = `
       class="css-kb54xq"
     >
       <div
-        class="css-1kwj960"
+        class="css-1myr2s0"
       >
         <picture
           class="css-128l0kk"
@@ -135,7 +135,7 @@ exports[`ArticleSidebar should render ArticleSidebar component 1`] = `
       class="css-kb54xq"
     >
       <div
-        class="css-1kwj960"
+        class="css-1myr2s0"
       >
         <picture
           class="css-128l0kk"

--- a/packages/ts-newskit/src/components/puzzles/article-sidebar/index.tsx
+++ b/packages/ts-newskit/src/components/puzzles/article-sidebar/index.tsx
@@ -3,7 +3,6 @@ import {
   TextBlock,
   Block,
   CardComposable,
-  CardMedia,
   CardContent,
   CardLink,
   Divider,
@@ -12,7 +11,7 @@ import {
 } from 'newskit';
 import { NewsKitChevronRightIcon } from '../../../assets';
 import { Puzzle } from './types';
-import { StyledCardComposable } from './styles';
+import { StyledCardComposable, StyledCardMedia } from './styles';
 
 export interface ArticleSideBarProps {
   sectionTitle: string;
@@ -79,7 +78,7 @@ export const ArticleSidebar: FC<ArticleSideBarProps> = ({
            media content          
          `}
           >
-            <CardMedia
+            <StyledCardMedia
               media={{
                 src: imgUrl,
                 height: '40px',

--- a/packages/ts-newskit/src/components/puzzles/article-sidebar/styles.ts
+++ b/packages/ts-newskit/src/components/puzzles/article-sidebar/styles.ts
@@ -1,4 +1,9 @@
-import { CardComposable, getColorCssFromTheme, styled } from 'newskit';
+import {
+  CardComposable,
+  getColorCssFromTheme,
+  styled,
+  CardMedia
+} from 'newskit';
 
 export const StyledCardComposable = styled(CardComposable)`
   &:hover {
@@ -8,5 +13,13 @@ export const StyledCardComposable = styled(CardComposable)`
   }
   h3 {
     color: inherit;
+  }
+`;
+
+export const StyledCardMedia = styled(CardMedia)`
+  picture {
+    min-height: 40px;
+    min-width: 60px;
+    background: transparent;
   }
 `;


### PR DESCRIPTION
### Description

Implemented a fix for the Article sidebar jumping issue that occurs when the placeholder is loading.


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):
#### Before
<img width="494" alt="Screenshot 2024-02-29 at 11 20 17 AM" src="https://github.com/newsuk/times-components/assets/105289286/5442487b-66c4-4020-901b-952a190edf4d">

#### After
<img width="367" alt="Screenshot 2024-02-29 at 11 23 47 AM" src="https://github.com/newsuk/times-components/assets/105289286/d4590f3d-5a4f-4929-ab7d-1ecceb46522f">

