### PR TITLE
feat(TMPZ-368): Use transparent icons for puzzle tiles and add a background color, enabling same images to be used on sidebar

### DIFF
--- a/packages/ts-newskit/src/components/puzzles/cards-container/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/cards-container/__tests__/__snapshots__/index.test.tsx.snap
@@ -181,7 +181,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-1ba9oov"
           >
             <div
-              class="lcpPuzzles css-2zeami"
+              class="lcpPuzzles css-8yodrv"
             >
               <picture
                 class="css-2pubdt"
@@ -198,7 +198,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -227,7 +227,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -286,7 +286,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-1ba9oov"
           >
             <div
-              class="lcpPuzzles css-2zeami"
+              class="lcpPuzzles css-8yodrv"
             >
               <picture
                 class="css-2pubdt"
@@ -303,7 +303,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -332,7 +332,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -391,7 +391,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-1ba9oov"
           >
             <div
-              class="lcpPuzzles css-2zeami"
+              class="lcpPuzzles css-8yodrv"
             >
               <picture
                 class="css-2pubdt"
@@ -408,7 +408,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -437,7 +437,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -496,7 +496,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-1ba9oov"
           >
             <div
-              class="lcpPuzzles css-2zeami"
+              class="lcpPuzzles css-8yodrv"
             >
               <picture
                 class="css-2pubdt"
@@ -513,7 +513,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -542,7 +542,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -601,7 +601,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-1ba9oov"
           >
             <div
-              class=" css-2zeami"
+              class=" css-8yodrv"
             >
               <picture
                 class="css-om84o6"
@@ -614,7 +614,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -643,7 +643,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -702,7 +702,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-1ba9oov"
           >
             <div
-              class=" css-2zeami"
+              class=" css-8yodrv"
             >
               <picture
                 class="css-om84o6"
@@ -715,7 +715,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -744,7 +744,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -803,7 +803,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-1ba9oov"
           >
             <div
-              class=" css-2zeami"
+              class=" css-8yodrv"
             >
               <picture
                 class="css-om84o6"
@@ -816,7 +816,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -845,7 +845,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -904,7 +904,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
             class="css-1ba9oov"
           >
             <div
-              class=" css-2zeami"
+              class=" css-8yodrv"
             >
               <picture
                 class="css-om84o6"
@@ -917,7 +917,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -946,7 +946,7 @@ exports[`CardsContainer tests should render a snapshot with scroller 1`] = `
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -1086,7 +1086,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-1ba9oov"
           >
             <div
-              class="lcpPuzzles css-2zeami"
+              class="lcpPuzzles css-8yodrv"
             >
               <picture
                 class="css-2pubdt"
@@ -1103,7 +1103,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -1132,7 +1132,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -1191,7 +1191,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-1ba9oov"
           >
             <div
-              class="lcpPuzzles css-2zeami"
+              class="lcpPuzzles css-8yodrv"
             >
               <picture
                 class="css-2pubdt"
@@ -1208,7 +1208,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -1237,7 +1237,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -1296,7 +1296,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-1ba9oov"
           >
             <div
-              class="lcpPuzzles css-2zeami"
+              class="lcpPuzzles css-8yodrv"
             >
               <picture
                 class="css-2pubdt"
@@ -1313,7 +1313,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -1342,7 +1342,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -1401,7 +1401,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-1ba9oov"
           >
             <div
-              class="lcpPuzzles css-2zeami"
+              class="lcpPuzzles css-8yodrv"
             >
               <picture
                 class="css-2pubdt"
@@ -1418,7 +1418,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -1447,7 +1447,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -1506,7 +1506,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-1ba9oov"
           >
             <div
-              class=" css-2zeami"
+              class=" css-8yodrv"
             >
               <picture
                 class="css-om84o6"
@@ -1519,7 +1519,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -1548,7 +1548,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -1607,7 +1607,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-1ba9oov"
           >
             <div
-              class=" css-2zeami"
+              class=" css-8yodrv"
             >
               <picture
                 class="css-om84o6"
@@ -1620,7 +1620,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -1649,7 +1649,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -1708,7 +1708,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-1ba9oov"
           >
             <div
-              class=" css-2zeami"
+              class=" css-8yodrv"
             >
               <picture
                 class="css-om84o6"
@@ -1721,7 +1721,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -1750,7 +1750,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -1809,7 +1809,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
             class="css-1ba9oov"
           >
             <div
-              class=" css-2zeami"
+              class=" css-8yodrv"
             >
               <picture
                 class="css-om84o6"
@@ -1822,7 +1822,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -1851,7 +1851,7 @@ exports[`CardsContainer tests should render a snapshot without scroller 1`] = `
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -1991,7 +1991,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
             class="css-1ba9oov"
           >
             <div
-              class="lcpPuzzles css-2zeami"
+              class="lcpPuzzles css-8yodrv"
             >
               <picture
                 class="css-2pubdt"
@@ -2008,7 +2008,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -2037,7 +2037,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -2096,7 +2096,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
             class="css-1ba9oov"
           >
             <div
-              class="lcpPuzzles css-2zeami"
+              class="lcpPuzzles css-8yodrv"
             >
               <picture
                 class="css-2pubdt"
@@ -2113,7 +2113,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -2142,7 +2142,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -2201,7 +2201,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
             class="css-1ba9oov"
           >
             <div
-              class="lcpPuzzles css-2zeami"
+              class="lcpPuzzles css-8yodrv"
             >
               <picture
                 class="css-2pubdt"
@@ -2218,7 +2218,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -2247,7 +2247,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -2306,7 +2306,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
             class="css-1ba9oov"
           >
             <div
-              class="lcpPuzzles css-2zeami"
+              class="lcpPuzzles css-8yodrv"
             >
               <picture
                 class="css-2pubdt"
@@ -2323,7 +2323,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -2352,7 +2352,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -2411,7 +2411,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
             class="css-1ba9oov"
           >
             <div
-              class=" css-2zeami"
+              class=" css-8yodrv"
             >
               <picture
                 class="css-om84o6"
@@ -2424,7 +2424,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -2453,7 +2453,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -2512,7 +2512,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
             class="css-1ba9oov"
           >
             <div
-              class=" css-2zeami"
+              class=" css-8yodrv"
             >
               <picture
                 class="css-om84o6"
@@ -2525,7 +2525,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -2554,7 +2554,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -2613,7 +2613,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
             class="css-1ba9oov"
           >
             <div
-              class=" css-2zeami"
+              class=" css-8yodrv"
             >
               <picture
                 class="css-om84o6"
@@ -2626,7 +2626,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -2655,7 +2655,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>
@@ -2714,7 +2714,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
             class="css-1ba9oov"
           >
             <div
-              class=" css-2zeami"
+              class=" css-8yodrv"
             >
               <picture
                 class="css-om84o6"
@@ -2727,7 +2727,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
                 />
               </picture>
               <div
-                class="css-11mq3i1"
+                class="css-7wldo2"
               >
                 <div
                   class="css-1az3j4h"
@@ -2756,7 +2756,7 @@ exports[`CardsContainer tests should render a snapshot without scroller and with
                     class="css-1xzc2un"
                   >
                     <div
-                      class="css-m1f215"
+                      class="css-ui5q32"
                     >
                       Puzzle Name
                     </div>

--- a/packages/ts-newskit/src/components/puzzles/puzzle-card/PuzzleCard.stories.mdx
+++ b/packages/ts-newskit/src/components/puzzles/puzzle-card/PuzzleCard.stories.mdx
@@ -23,19 +23,23 @@ This component takes in the following props:
 ## View Component
 Please click the 'Canvas' tab for a better viewing experience, where you can review and configure with different titles.
 
-export const PuzzleCardStory = ({data, isImageCropped}) => (
+export const PuzzleCardStory = ({data, isImageCropped, bgColor}) => (
   <NewsKitProvider theme={PuzzlesWebLightTheme}>
-    <PuzzleCard {...{data}} isImageCropped={isImageCropped}/>
+    <PuzzleCard {...{data}} isImageCropped={isImageCropped} bgColor={bgColor}/>
   </NewsKitProvider>
 );
 
 <Story
   name="PuzzleCard"
-  args={{ data: puzzles.list[0] }}
+  args={{ data: puzzles.list[0], bgColor: '#FEEEDC' }}
   argTypes={{
     isImageCropped: {
         control: 'boolean',
         name: 'Is Image Cropped'
+    },
+    bgColor: {
+      control: 'color',
+      name: 'Background Color'
     }
   }}
 >

--- a/packages/ts-newskit/src/components/puzzles/puzzle-card/__tests__/__snapshots__/PuzzleCard.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/puzzle-card/__tests__/__snapshots__/PuzzleCard.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Puzzle Card should render Puzzle Card 1`] = `
     class="css-1ba9oov"
   >
     <div
-      class="lcpPuzzles css-2zeami"
+      class="lcpPuzzles css-8yodrv"
     >
       <picture
         class="css-2pubdt"
@@ -23,7 +23,7 @@ exports[`Puzzle Card should render Puzzle Card 1`] = `
         />
       </picture>
       <div
-        class="css-11mq3i1"
+        class="css-7wldo2"
       >
         <div
           class="css-1az3j4h"
@@ -52,7 +52,7 @@ exports[`Puzzle Card should render Puzzle Card 1`] = `
             class="css-1xzc2un"
           >
             <div
-              class="css-m1f215"
+              class="css-ui5q32"
             >
               Polygon
             </div>

--- a/packages/ts-newskit/src/components/puzzles/puzzle-card/index.tsx
+++ b/packages/ts-newskit/src/components/puzzles/puzzle-card/index.tsx
@@ -14,12 +14,14 @@ export interface PuzzleCardProps {
   data: Puzzle;
   isImageCropped?: boolean;
   isLazyLoading?: boolean;
+  bgColor?: string;
 }
 
 export const PuzzleCard = ({
   data,
   isImageCropped = false,
-  isLazyLoading = false
+  isLazyLoading = false,
+  bgColor = '#FEEEDC'
 }: PuzzleCardProps) => {
   const publishedDate = convertDateToWeekday(data.publishedAt);
   const imageUrl = data.image ? data.image.crops[0].url : '';
@@ -33,7 +35,10 @@ export const PuzzleCard = ({
         stylePreset: 'puzzleCard'
       }}
     >
-      <PuzzleCardImgWrapper className={isLazyLoading ? '' : 'lcpPuzzles'}>
+      <PuzzleCardImgWrapper
+        className={isLazyLoading ? '' : 'lcpPuzzles'}
+        bgColor={bgColor}
+      >
         {imageUrl ? (
           <Image
             loadingAspectRatio="3:2"
@@ -69,6 +74,7 @@ export const PuzzleCard = ({
               as="div"
               marginBlock="space020"
               marginInline="space020"
+              marginBlockStart="space030"
               stylePreset="inkContrast"
               typographyPreset={{
                 xs: 'editorialHeadline010',

--- a/packages/ts-newskit/src/components/puzzles/puzzle-card/styles.ts
+++ b/packages/ts-newskit/src/components/puzzles/puzzle-card/styles.ts
@@ -3,7 +3,7 @@ import { NewsKitPuzzlePlaceholder } from './assets';
 
 export const Wrap = styled(Block)`
   position: absolute;
-  top: 39%;
+  top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
 `;
@@ -13,11 +13,12 @@ export const PuzzleCardComposable = styled(CardComposable)`
   flex-direction: column;
 `;
 
-export const PuzzleCardImgWrapper = styled(Block)`
+export const PuzzleCardImgWrapper = styled(Block)<{ bgColor?: string }>`
   position: relative;
   display: flex;
   height: 0;
   padding-bottom: 66.6%;
+  background-color: ${props => props.bgColor};
 
   img {
     aspect-ratio: 3/2;


### PR DESCRIPTION
### Description

To add the background color for the puzzle tiles.

[TMPZ-368](https://nidigitalsolutions.jira.com/browse/TMPZ-368)


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):
<img width="1553" alt="Screenshot 2024-03-01 at 6 14 30 PM" src="https://github.com/newsuk/times-components/assets/105289286/a8b222d0-dc26-471d-b8b8-9e3c02498fb5">


[TMPZ-368]: https://nidigitalsolutions.jira.com/browse/TMPZ-368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ