### PR TITLE
fix(TMRX-1734): video play button bugs

### DIFF
--- a/packages/video/src/inline-video-player.js
+++ b/packages/video/src/inline-video-player.js
@@ -19,7 +19,7 @@ const css = `
     width: 100%;
     background-color: unset !important;
 
-    &::before {
+    &::before, &::after {
       content: "";
 
       position: absolute;
@@ -38,12 +38,21 @@ const css = `
       min-height: 80px;
       max-width: 128px;
       max-height: 128px;
-
-      transition: background-image 100ms ease-in-out;
+      transition: opacity 100ms ease-in-out;
     }
 
-    span:before {
-      display: none;
+    &::before {
+      background-image: url(${videoPlayIcon.base});
+      opacity: 1;
+    }
+
+    &::after {
+      background-image: url(${videoPlayIcon.hover});
+      opacity: 0;
+    }
+
+    span::before {
+      display: none;  
     }
 
     &:focus {
@@ -54,7 +63,10 @@ const css = `
     }
     &:hover {
       &::before {
-        background-image: url(${videoPlayIcon.hover});
+        opacity: 0;
+      }
+      &::after {
+        opacity: 1;
       }
     }
   }


### PR DESCRIPTION
### Description

Fixes the following bugs with the video play button:

1. Double video icon on older chrome versions
![image](https://github.com/newsuk/times-components/assets/142982056/f5856d3f-ad2c-4690-8391-4a87a5d3e7d4)

2. On Safari the icon appears to jump when hovering over the player


[JIRA-1734](https://nidigitalsolutions.jira.com/browse/TMRX-1734)


### Checklist

- [X] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots:

**Before**

https://github.com/newsuk/times-components/assets/142982056/3bc26af6-c19f-4756-b08d-c537e6c7b661



**After**

https://github.com/newsuk/times-components/assets/142982056/ec16459c-7ca5-49de-b891-f079ec3ac669



