### PR TITLE
feat(TMPZ-367): Update puzzle icons in sidebar to align with the new illustrations

### DIFF
--- a/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -760,7 +760,7 @@ exports[`5. an article with puzzle sidebar 1`] = `
                   <img
                     alt="Puzzle thumbnail"
                     height="40px"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0&resize=500"
+                    src="https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/crossword-cf4c909719.png"
                     width="auto"
                   />
                 </picture>
@@ -804,7 +804,7 @@ exports[`5. an article with puzzle sidebar 1`] = `
                   <img
                     alt="Puzzle thumbnail"
                     height="40px"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F04934dfb-0e8f-4f00-872d-c796fed01ba3.png?crop=1250%2C833%2C0%2C0&resize=500"
+                    src="https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/polygon-2ae76bd129.png"
                     width="auto"
                   />
                 </picture>
@@ -846,7 +846,7 @@ exports[`5. an article with puzzle sidebar 1`] = `
                   <img
                     alt="Puzzle thumbnail"
                     height="40px"
-                    src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2Fadeba5d7-ec95-4435-82f3-7837c2b02072.png?crop=1250%2C833%2C0%2C0&resize=500"
+                    src="https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/sudoku-e2302ed30e.png"
                     width="auto"
                   />
                 </picture>

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -867,7 +867,7 @@ exports[`6. an article with puzzle sidebar 1`] = `
                     <img
                       alt="Puzzle thumbnail"
                       height="40px"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0&resize=500"
+                      src="https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/crossword-cf4c909719.png"
                       width="auto"
                     />
                   </picture>
@@ -911,7 +911,7 @@ exports[`6. an article with puzzle sidebar 1`] = `
                     <img
                       alt="Puzzle thumbnail"
                       height="40px"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F04934dfb-0e8f-4f00-872d-c796fed01ba3.png?crop=1250%2C833%2C0%2C0&resize=500"
+                      src="https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/polygon-2ae76bd129.png"
                       width="auto"
                     />
                   </picture>
@@ -953,7 +953,7 @@ exports[`6. an article with puzzle sidebar 1`] = `
                     <img
                       alt="Puzzle thumbnail"
                       height="40px"
-                      src="https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2Fadeba5d7-ec95-4435-82f3-7837c2b02072.png?crop=1250%2C833%2C0%2C0&resize=500"
+                      src="https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/sudoku-e2302ed30e.png"
                       width="auto"
                     />
                   </picture>

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -338,19 +338,19 @@ const ArticleSkeleton = ({
                             title: "Crossword",
                             url: "https://www.thetimes.co.uk/puzzles/crossword",
                             imgUrl:
-                              "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0&resize=500"
+                              "https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/crossword-cf4c909719.png"
                           },
                           {
                             title: "Polygon",
                             url: polygonUrl,
                             imgUrl:
-                              "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F04934dfb-0e8f-4f00-872d-c796fed01ba3.png?crop=1250%2C833%2C0%2C0&resize=500"
+                              "https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/polygon-2ae76bd129.png"
                           },
                           {
                             title: "Sudoku",
                             url: "https://www.thetimes.co.uk/puzzles/sudoku",
                             imgUrl:
-                              "https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2Fadeba5d7-ec95-4435-82f3-7837c2b02072.png?crop=1250%2C833%2C0%2C0&resize=500"
+                              "https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/sudoku-e2302ed30e.png"
                           }
                         ]}
                       />

--- a/packages/ts-newskit/src/components/puzzles/article-sidebar/ArticleSidebar.stories.mdx
+++ b/packages/ts-newskit/src/components/puzzles/article-sidebar/ArticleSidebar.stories.mdx
@@ -27,7 +27,7 @@ export const ArticleSidebarStory = ({sectionTitle, data, pageLink}) => (
   </NewsKitProvider>
 ); 
 
-<Story name="ArticleSidebar" args={{ sectionTitle: 'Puzzles', data:[{title: 'Crossword', url: 'https://www.thetimes.co.uk/puzzles/crossword', imgUrl: 'https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0&resize=500'}, {title: 'Polygon', url: 'https://www.thetimes.co.uk/puzzles/word-puzzles', imgUrl: 'https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0&resize=500'}, {title: 'Sudoku', url: 'https://www.thetimes.co.uk/puzzles/sudoku', imgUrl: 'https://www.thetimes.co.uk/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0&resize=500'}], pageLink:'https://www.thetimes.co.uk/puzzles'
+<Story name="ArticleSidebar" args={{ sectionTitle: 'Puzzles', data:[{title: 'Crossword', url: 'https://www.thetimes.co.uk/puzzles/crossword', imgUrl: 'https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/crossword-cf4c909719.png'}, {title: 'Polygon', url: 'https://www.thetimes.co.uk/puzzles/word-puzzles', imgUrl: 'https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/polygon-2ae76bd129.png'}, {title: 'Sudoku', url: 'https://www.thetimes.co.uk/puzzles/sudoku', imgUrl: 'https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/sudoku-e2302ed30e.png'}], pageLink:'https://www.thetimes.co.uk/puzzles'
   
 }}>
   {ArticleSidebarStory.bind({})}

--- a/packages/ts-newskit/src/components/puzzles/article-sidebar/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-newskit/src/components/puzzles/article-sidebar/__tests__/__snapshots__/index.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`ArticleSidebar should render ArticleSidebar component 1`] = `
       class="css-kb54xq"
     >
       <div
-        class="css-1myr2s0"
+        class="css-1dxb1j1"
       >
         <picture
           class="css-128l0kk"
@@ -135,7 +135,7 @@ exports[`ArticleSidebar should render ArticleSidebar component 1`] = `
       class="css-kb54xq"
     >
       <div
-        class="css-1myr2s0"
+        class="css-1dxb1j1"
       >
         <picture
           class="css-128l0kk"

--- a/packages/ts-newskit/src/components/puzzles/article-sidebar/styles.ts
+++ b/packages/ts-newskit/src/components/puzzles/article-sidebar/styles.ts
@@ -19,7 +19,7 @@ export const StyledCardComposable = styled(CardComposable)`
 export const StyledCardMedia = styled(CardMedia)`
   picture {
     min-height: 40px;
-    min-width: 60px;
+    min-width: 40px;
     background: transparent;
   }
 `;


### PR DESCRIPTION
### Description

Updated new puzzle images on the sidebar.

[TMPZ-367](https://nidigitalsolutions.jira.com/browse/TMPZ-367)


### Checklist

- [X] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):
<img width="1202" alt="Screenshot 2024-03-12 at 4 45 41 PM" src="https://github.com/newsuk/times-components/assets/105289286/850815fd-866d-4dc3-bc59-f531dfbcf9f3">

