### PR TITLE
chore(TMW-000): Node 18 upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ version: 2.1
 executors:
     node:
         docker:
-          - image: cimg/node:16.14.0-browsers
+          - image: cimg/node:18.19.1-browsers
         resource_class: 2xlarge
     node_sonar:
         docker:
-          - image: cimg/node:16.13.1
+          - image: cimg/node:18.19.1
         resource_class: small
 
 orbs:

--- a/.storybook/vendor.webpack.config.js
+++ b/.storybook/vendor.webpack.config.js
@@ -1,5 +1,9 @@
 const path = require("path");
 const webpack = require("webpack");
+const crypto = require("crypto");
+
+const crypto_orig_createHash = crypto.createHash;
+crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
 
 module.exports = {
   context: process.cwd(),

--- a/.storybook/vendor.webpack.config.js
+++ b/.storybook/vendor.webpack.config.js
@@ -2,8 +2,9 @@ const path = require("path");
 const webpack = require("webpack");
 const crypto = require("crypto");
 
-const crypto_orig_createHash = crypto.createHash;
-crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
+const cryptoCreateHash = crypto.createHash;
+crypto.createHash = algorithm =>
+  cryptoCreateHash(algorithm === "md4" ? "sha256" : algorithm);
 
 module.exports = {
   context: process.cwd(),

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -2,8 +2,9 @@ const path = require("path");
 const webpack = require("webpack");
 const crypto = require("crypto");
 
-const crypto_orig_createHash = crypto.createHash;
-crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
+const cryptoCreateHash = crypto.createHash;
+crypto.createHash = algorithm =>
+  cryptoCreateHash(algorithm === "md4" ? "sha256" : algorithm);
 
 module.exports = async ({ config }, env, defaultConfig) => {
   config.devtool = "eval-source-map";

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,5 +1,9 @@
 const path = require("path");
 const webpack = require("webpack");
+const crypto = require("crypto");
+
+const crypto_orig_createHash = crypto.createHash;
+crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
 
 module.exports = async ({ config }, env, defaultConfig) => {
   config.devtool = "eval-source-map";

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "npm:publish-canary": "bash ./lib/publish_canary.sh",
     "cinstall": "bash ./lib/custom_install.sh",
     "clean": "watchman watch-del-all && rm -rf $TMPDIR/metro-* && rm -rf $TMPDIR/haste-* && yarn cache clean && jest --clearCache",
-    "bundle": "lerna run bundle",
+    "bundle": "NODE_OPTIONS=--openssl-legacy-provider lerna run bundle",
     "build:local": "yarn install && yarn bundle && yarn prepublishOnly",
     "postinstall": "yarn run copy-fonts && lerna run postinstall && lerna run transpile",
     "packages:publish": "lerna publish --conventional-commits --yes --concurrency=1 --exact",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A collection of presentational components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {
-    "node": ">=10.13.0",
+    "node": ">=18.19.1",
     "yarn": ">=1.16.0"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "npm:publish-canary": "bash ./lib/publish_canary.sh",
     "cinstall": "bash ./lib/custom_install.sh",
     "clean": "watchman watch-del-all && rm -rf $TMPDIR/metro-* && rm -rf $TMPDIR/haste-* && yarn cache clean && jest --clearCache",
-    "bundle": "NODE_OPTIONS=--openssl-legacy-provider lerna run bundle",
+    "bundle": "lerna run bundle",
     "build:local": "yarn install && yarn bundle && yarn prepublishOnly",
     "postinstall": "yarn run copy-fonts && lerna run postinstall && lerna run transpile",
     "packages:publish": "lerna publish --conventional-commits --yes --concurrency=1 --exact",

--- a/packages/ssr/src/standalone-renderer/webpack.config.js
+++ b/packages/ssr/src/standalone-renderer/webpack.config.js
@@ -2,8 +2,9 @@ const path = require("path");
 const crypto = require("crypto");
 const outputFolder = require("../lib/resolve-dist");
 
-const crypto_orig_createHash = crypto.createHash;
-crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
+const cryptoCreateHash = crypto.createHash;
+crypto.createHash = algorithm =>
+  cryptoCreateHash(algorithm === "md4" ? "sha256" : algorithm);
 
 module.exports = () => ({
   entry: {

--- a/packages/ssr/src/standalone-renderer/webpack.config.js
+++ b/packages/ssr/src/standalone-renderer/webpack.config.js
@@ -1,5 +1,9 @@
 const path = require("path");
+const crypto = require("crypto");
 const outputFolder = require("../lib/resolve-dist");
+
+const crypto_orig_createHash = crypto.createHash;
+crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
 
 module.exports = () => ({
   entry: {

--- a/packages/ssr/webpack.config.js
+++ b/packages/ssr/webpack.config.js
@@ -2,8 +2,9 @@ const path = require("path");
 const crypto = require("crypto");
 const outputFolder = require("./src/lib/resolve-dist");
 
-const crypto_orig_createHash = crypto.createHash;
-crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
+const cryptoCreateHash = crypto.createHash;
+crypto.createHash = algorithm =>
+  cryptoCreateHash(algorithm === "md4" ? "sha256" : algorithm);
 
 const extensions = [".js"];
 

--- a/packages/ssr/webpack.config.js
+++ b/packages/ssr/webpack.config.js
@@ -1,5 +1,9 @@
 const path = require("path");
+const crypto = require("crypto");
 const outputFolder = require("./src/lib/resolve-dist");
+
+const crypto_orig_createHash = crypto.createHash;
+crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
 
 const extensions = [".js"];
 

--- a/packages/webpack-configurator/src/configurator.js
+++ b/packages/webpack-configurator/src/configurator.js
@@ -1,8 +1,9 @@
 import path from "path";
 import crypto from "crypto";
 
-const crypto_orig_createHash = crypto.createHash;
-crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
+const cryptoCreateHash = crypto.createHash;
+crypto.createHash = algorithm =>
+  cryptoCreateHash(algorithm === "md4" ? "sha256" : algorithm);
 
 export default ({ exists, readFile }, resolve) => {
   const parseJson = async pathToJson =>

--- a/packages/webpack-configurator/src/configurator.js
+++ b/packages/webpack-configurator/src/configurator.js
@@ -1,4 +1,8 @@
 import path from "path";
+import crypto from "crypto";
+
+const crypto_orig_createHash = crypto.createHash;
+crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
 
 export default ({ exists, readFile }, resolve) => {
   const parseJson = async pathToJson =>


### PR DESCRIPTION
### Description

Upgrade to Node `18.19.1` https://nidigitalsolutions.jira.com/browse/TMRX-1881

Webpack and certain Webpack plugins use MD4 hashing algorithm which is no longer available in OpenSSL 3.0+ which ships with Node 17+. In order to continue using the legacy algorithm this PR creates a proxy function which swaps `md4` for `sha256`.

_**This is the current workaround but the full solution should be to upgrade Webpack and other dependancies to work correctly without falling back to insecure functions.**_


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
