### PR TITLE
Feat(TMD-000): Added banner stylings

### DIFF
--- a/packages/article-skeleton/src/styles/responsive.js
+++ b/packages/article-skeleton/src/styles/responsive.js
@@ -110,4 +110,10 @@ export const EmailBannerContainer = styled.div`
   z-index: 100;
   display: flex;
   justify-content: center;
+  height: 100%;
+  @media (max-width: ${breakpoints.medium}px) {
+    max-width: 327px;
+    height: 100px;
+    margin: auto;
+  }
 `;

--- a/packages/ts-newskit/src/components/misc/banner/__tests__/__snapshots__/banner.test.tsx.snap
+++ b/packages/ts-newskit/src/components/misc/banner/__tests__/__snapshots__/banner.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`Banner renders the banner 1`] = `
 <DocumentFragment>
   <div
-    class="css-1tu1y1s"
+    class="css-197qwxt"
   >
     <div
       class="css-gre9re"
     >
       <div
         aria-label="Email verification banner"
-        class="css-1gud7zt"
+        class="css-1qyqnch"
         data-testid="banner-container"
         role="region"
       >
@@ -36,7 +36,7 @@ exports[`Banner renders the banner 1`] = `
                       class="css-s5sjj8"
                     >
                       <div
-                        class="css-1x0hqjg"
+                        class="css-1bjb3mr"
                       >
                         <div
                           class="css-1vptl7o"
@@ -55,7 +55,7 @@ exports[`Banner renders the banner 1`] = `
                             />
                           </svg>
                           <p
-                            class="css-1v8qzr2"
+                            class="css-hk5gs7"
                           >
                             Title
                           </p>
@@ -79,7 +79,7 @@ exports[`Banner renders the banner 1`] = `
                         </button>
                       </div>
                       <p
-                        class="css-ek7xhi"
+                        class="css-j9qpwq"
                       >
                         Body
                       </p>
@@ -97,7 +97,7 @@ exports[`Banner renders the banner 1`] = `
     >
       <div
         aria-label="Email verification banner"
-        class="css-1gud7zt"
+        class="css-1qyqnch"
         data-testid="banner-container"
         role="region"
       >
@@ -123,7 +123,7 @@ exports[`Banner renders the banner 1`] = `
                       class="css-s5sjj8"
                     >
                       <div
-                        class="css-1x0hqjg"
+                        class="css-1bjb3mr"
                       >
                         <div
                           class="css-1vptl7o"
@@ -142,7 +142,7 @@ exports[`Banner renders the banner 1`] = `
                             />
                           </svg>
                           <p
-                            class="css-1v8qzr2"
+                            class="css-hk5gs7"
                           >
                             Title
                           </p>
@@ -166,7 +166,7 @@ exports[`Banner renders the banner 1`] = `
                         </button>
                       </div>
                       <p
-                        class="css-ek7xhi"
+                        class="css-j9qpwq"
                       >
                         Body
                       </p>

--- a/packages/ts-newskit/src/components/misc/banner/styles.ts
+++ b/packages/ts-newskit/src/components/misc/banner/styles.ts
@@ -1,10 +1,11 @@
 import { styled, Banner, TextBlock } from 'newskit';
+import { breakpoints } from '@times-components/ts-styleguide';
 
 export const BannerWrapper = styled.div`
-  width: 100%;
   max-width: 498px;
   box-shadow: 0px 16px 24px 0px rgba(17, 17, 17, 0.08);
   z-index: 100;
+  width: 100%;
 `;
 
 export const NewsKitBanner = styled(Banner)`
@@ -13,6 +14,7 @@ export const NewsKitBanner = styled(Banner)`
   padding: 16px;
   flex-direction: column;
   align-items: flex-start;
+  height: 83px;
 `;
 
 export const Wrapper = styled.div`
@@ -20,7 +22,7 @@ export const Wrapper = styled.div`
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  margin-bottom: 8px;
+  margin-bottom: 16px;
 `;
 
 export const TitleWrapper = styled.div`
@@ -33,12 +35,24 @@ export const Title = styled(TextBlock)`
   color: #333;
   font-weight: 700;
   margin: 0 0 0 16px;
+  font-size: 24px;
+  line-height: 27px;
+  @media (max-width: ${breakpoints.medium}px) {
+    font-size: 18px;
+    line-height: 20px;
+  }
 `;
 
 export const Body = styled(TextBlock)`
   color: #696969;
   font-weight: 400;
   margin: 0;
+  font-size: 16px;
+  line-height: 24px;
+  @media (max-width: ${breakpoints.medium}px) {
+    font-size: 14px;
+    line-height: 21px;
+  }
 `;
 
 export const CloseIconWrapper = styled.button`


### PR DESCRIPTION
### Description

Implemented banner using the Newskit Design system for verify-email reminder 

[TMG-1344](https://nidigitalsolutions.jira.com/browse/TMG-1344)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

<img width="1212" alt="image" src="https://github.com/newsuk/times-components/assets/118182607/fea34975-7895-4cb2-bc09-f40d2a728b70">



[TMG-1344]: https://nidigitalsolutions.jira.com/browse/TMG-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ