### PR TITLE
spike(TMRS-147): update for persisted audio POC

### DIFF
--- a/packages/save-and-share-bar/src/save-and-share-bar.js
+++ b/packages/save-and-share-bar/src/save-and-share-bar.js
@@ -2,6 +2,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { TcText, TcView, checkStylesForUnits } from "@times-components/utils";
+import { InArticleAudio } from "@times-components/ts-newskit";
 import {
   IconFacebook,
   IconTwitter,
@@ -45,6 +46,18 @@ class SaveAndShareBar extends Component {
 
     return (
       <TcView style={styles.container} data-testid="save-and-share-bar">
+        <InArticleAudio
+          src="https://www.thetimes.co.uk/d/optimizely/james-marriott-alt-top-2.mp3"
+          readyToPlayText='Listen to article'
+          playingText='Playing'
+          narrator='James Marriott'
+          headline='Article headline'
+          feedback={{
+            requestFeedback: true,
+            feedbackMessage: "Want to listen to more articles? Give your feedback below or email",
+            thankyouMessage: "Thank you for your feedback. We're always trying to give you the best possible experience – your feedback helps us do this."
+          }}
+        />
         {sharingEnabled && (
           <TcView style={styles.rowItem}>
             <TcText style={checkStylesForUnits(styles.label)}>Share</TcText>

--- a/packages/save-and-share-bar/src/styles/index.js
+++ b/packages/save-and-share-bar/src/styles/index.js
@@ -10,7 +10,8 @@ const styles = {
     paddingTop: spacing(2),
     paddingBottom: spacing(2),
     height: "100%",
-    alignItems: "center"
+    alignItems: "center",
+    zIndex: 100
   },
   activityLoader: {
     borderRadius: 9999,

--- a/packages/ts-components/package.json
+++ b/packages/ts-components/package.json
@@ -18,10 +18,10 @@
   "homepage": "https://github.com/newsuk/times-components#readme",
   "scripts": {
     "describe": "npm-scripts-info",
-    "transpile": "run-s build",
+    "_transpile": "run-s build",
     "build": "run-s clean && run-p build:*",
     "build:module": "tsc -p tsconfig.json",
-    "bundle": "NODE_ENV=production webpack -p",
+    "_bundle": "NODE_ENV=production webpack -p",
     "depcheck": "depcheck --ignores='@babel/*,babel-*,depcheck,eslint,tslint*,typescript,jest,prettier,webpack*,@types/*' --ignore-bin-package=false --skip-missing",
     "fix": "run-s fix:*",
     "fix:prettier": "prettier \"src/**/*.{ts,tsx}\" \"__tests__/**/*.tsx\" --write",

--- a/packages/ts-newskit/src/components/article-audio/in-article-audio.stories.mdx
+++ b/packages/ts-newskit/src/components/article-audio/in-article-audio.stories.mdx
@@ -19,7 +19,7 @@ This takes in a `data` prop, as below, to display the links in their order withi
 ## Code Example
 ```
 <InArticleAudio
-  src="https://ncu-newskit-docs.s3.eu-west-1.amazonaws.com/storybook-assets/audio_file_1.mp3"
+  src="https://www.thetimes.co.uk/d/optimizely/james-marriott-alt-top-2.mp3"
   readyToPlayText='Listen to article'
   playingText='Playing'
   narrator='James Marriott'
@@ -44,7 +44,7 @@ export const InArticleAudioStory = ({ src, readyToPlayText, playingText, narrato
 );
 
 <Story name="InArticleAudio" args={{ 
-  src: "https://www.thetimes.co.uk/d/optimizely/manveen-business-column-read.mp3",
+  src: "https://www.thetimes.co.uk/d/optimizely/james-marriott-alt-top-2.mp3",
   readyToPlayText: 'Listen to article',
   playingText: 'Playing',
   narrator: 'James Marriott',

--- a/packages/ts-newskit/src/components/article-audio/styles.ts
+++ b/packages/ts-newskit/src/components/article-audio/styles.ts
@@ -54,7 +54,7 @@ export const AudioPlayerContainer = styled(Block)`
   width: 100%;
 
   &.opHide_articleAudio {
-    display: none;
+    display: block;
   }
   &.opShow_articleAudio {
     display: block;

--- a/packages/ts-slices/package.json
+++ b/packages/ts-slices/package.json
@@ -18,10 +18,10 @@
   "homepage": "https://github.com/newsuk/times-components#readme",
   "scripts": {
     "describe": "npm-scripts-info",
-    "transpile": "run-s build",
+    "_transpile": "run-s build",
     "build": "run-s clean && run-p build:*",
     "build:module": "tsc -p tsconfig.json",
-    "bundle": "NODE_ENV=production webpack -p",
+    "_bundle": "NODE_ENV=production webpack -p",
     "fix": "run-s fix:*",
     "fix:prettier": "prettier \"src/**/*.{ts,tsx}\" \"__tests__/**/*.tsx\" --write",
     "fix:tslint": "tslint --fix --project .",


### PR DESCRIPTION
### Description

POC to enable persisted audio from articles on The Times.
Clicking the 'play' button will open a new tab containing a media player, and interaction with the `InArticleAudio` component will send data to the media player in the new tab using the `BroadcastChannel` API through the `postMessage` method.

Spike docs
https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/4855234561/Spike+TMRS-147+-+Persisted+audio+component+POC

Render PR
https://github.com/newsuk/times-components/compare/spike/TMRS-147_persist-audio-player?expand=1

[TMRS-147](https://nidigitalsolutions.jira.com/browse/TMRS-147)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.
