### PR TITLE
feat(TMD-177): remove low res and set a small default

### DIFF
--- a/packages/image/src/image.js
+++ b/packages/image/src/image.js
@@ -32,13 +32,10 @@ class TimesImage extends Component {
     });
   }
 
-  highResImage({ highResSize, url }) {
+  highResImage({ highResSize = 300, url }) {
     const { highResIsLoaded } = this.state;
     const { accessibilityLabel } = this.props;
-    const imgUrl = highResSize
-      ? appendToImageURL(url, "resize", highResSize)
-      : url;
-
+    const imgUrl = appendToImageURL(url, "resize", highResSize);
     return (
       <StyledImage
         alt={accessibilityLabel}


### PR DESCRIPTION
### Description

After further investigation, it seems react sends the requests through with a null value to start, then replaces it with the highRes value when it knows what dimensions are on board, this means for some images it's asking for the full size before the restricted one, which can be MB's in size, so have put a default small value to restrict this.

[TMD-177](https://nidigitalsolutions.jira.com/browse/TMD-177)


[TMD-177]: https://nidigitalsolutions.jira.com/browse/TMD-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ