### PR TITLE
fix(TMD-529): add background colour to image container

### DIFF
--- a/packages/article-list/__tests__/web/__snapshots__/article-list-error-with-styles.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list-error-with-styles.web.test.js.snap
@@ -155,6 +155,7 @@ exports[`1. page error 1`] = `
     className="c1"
   >
     <div
+      backgroundColor="#efefef"
       className="c2"
     >
       <div

--- a/packages/image/__tests__/web/__snapshots__/image-with-style.web.test.js.snap
+++ b/packages/image/__tests__/web/__snapshots__/image-with-style.web.test.js.snap
@@ -27,6 +27,7 @@ exports[`1. default image 1`] = `
 }
 
 <div
+  backgroundColor="#efefef"
   className="c0"
 >
   <div
@@ -66,6 +67,7 @@ exports[`2. default modal 1`] = `
 }
 
 <div
+  backgroundColor="#efefef"
   className="c0"
 >
   <div

--- a/packages/image/src/image.js
+++ b/packages/image/src/image.js
@@ -35,6 +35,7 @@ class TimesImage extends Component {
     const styles = {
       ...style
     };
+    Object.assign(styles, { backgroundColor: "#efefef" });
     if (rounded) {
       Object.assign(styles, { borderRadius: "50%", overflow: "hidden" });
     }

--- a/packages/ts-components/src/components/latest-from-section/__tests__/__snapshots__/LatestFromSection.test.tsx.snap
+++ b/packages/ts-components/src/components/latest-from-section/__tests__/__snapshots__/LatestFromSection.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`<LatestFromSection> renders  1`] = `
                           style="padding-bottom: 56.25%;"
                         >
                           <img
-                            class="responsive-sc-1nnon4d-0 bAbKns"
+                            class="responsive-sc-1nnon4d-0 ghIzdc"
                             loading="lazy"
                             src="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7fca746-d8ec-11eb-8f14-0bb645f59db0.jpg"
                           />
@@ -164,7 +164,7 @@ exports[`<LatestFromSection> renders  1`] = `
                           style="padding-bottom: 56.25%;"
                         >
                           <img
-                            class="responsive-sc-1nnon4d-0 bAbKns"
+                            class="responsive-sc-1nnon4d-0 ghIzdc"
                             loading="lazy"
                             src="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F65e48858-d913-11eb-b92f-5fe539a30c29.jpg"
                           />
@@ -253,7 +253,7 @@ exports[`<LatestFromSection> renders  1`] = `
                           style="padding-bottom: 56.25%;"
                         >
                           <img
-                            class="responsive-sc-1nnon4d-0 bAbKns"
+                            class="responsive-sc-1nnon4d-0 ghIzdc"
                             loading="lazy"
                             src="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F798e1dce-d918-11eb-b92f-5fe539a30c29.jpg"
                           />

--- a/packages/ts-components/src/components/latest-from-section/__tests__/__snapshots__/LatestFromSection.test.tsx.snap
+++ b/packages/ts-components/src/components/latest-from-section/__tests__/__snapshots__/LatestFromSection.test.tsx.snap
@@ -70,12 +70,13 @@ exports[`<LatestFromSection> renders  1`] = `
                     >
                       <div
                         class="tc-view__TcView-nuazoi-0 fPjBcr"
+                        style="background-color: rgb(239, 239, 239);"
                       >
                         <div
                           style="padding-bottom: 56.25%;"
                         >
                           <img
-                            class="responsive-sc-1nnon4d-0 ghIzdc"
+                            class="responsive-sc-1nnon4d-0 bAbKns"
                             loading="lazy"
                             src="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7fca746-d8ec-11eb-8f14-0bb645f59db0.jpg"
                           />
@@ -159,12 +160,13 @@ exports[`<LatestFromSection> renders  1`] = `
                     >
                       <div
                         class="tc-view__TcView-nuazoi-0 fPjBcr"
+                        style="background-color: rgb(239, 239, 239);"
                       >
                         <div
                           style="padding-bottom: 56.25%;"
                         >
                           <img
-                            class="responsive-sc-1nnon4d-0 ghIzdc"
+                            class="responsive-sc-1nnon4d-0 bAbKns"
                             loading="lazy"
                             src="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F65e48858-d913-11eb-b92f-5fe539a30c29.jpg"
                           />
@@ -248,12 +250,13 @@ exports[`<LatestFromSection> renders  1`] = `
                     >
                       <div
                         class="tc-view__TcView-nuazoi-0 fPjBcr"
+                        style="background-color: rgb(239, 239, 239);"
                       >
                         <div
                           style="padding-bottom: 56.25%;"
                         >
                           <img
-                            class="responsive-sc-1nnon4d-0 ghIzdc"
+                            class="responsive-sc-1nnon4d-0 bAbKns"
                             loading="lazy"
                             src="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F798e1dce-d918-11eb-b92f-5fe539a30c29.jpg"
                           />


### PR DESCRIPTION
so that image spaces where images are loading are defined and don't look like washed out white areas of the page

### Description

By removing the placeholder it removed the definition or outline of the page where images are loaded into, so by putting the background colour in it returns the definition, without the complication of the placeholder removed with [TMD-329](https://nidigitalsolutions.jira.com/browse/TMD-329)

[TMD-000](https://nidigitalsolutions.jira.com/browse/TMD-000)

### Screenshots (if appropriate):

![image](https://github.com/newsuk/times-components/assets/89213300/fa7a7046-ac3d-4eca-b13c-866f44188b69)

[TMD-329]: https://nidigitalsolutions.jira.com/browse/TMD-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ