### PR TITLE
feat(TMW-000): Update article ad positions

### DIFF
--- a/packages/article-skeleton/fixtures/inline-ad.js
+++ b/packages/article-skeleton/fixtures/inline-ad.js
@@ -102,6 +102,10 @@ const contentWithOutAd = [
       {
         name: "paragraph",
         children: []
+      },
+      {
+        name: "paragraph",
+        children: []
       }
     ]
   }
@@ -188,6 +192,10 @@ const contentWithAd = [
         children: []
       },
       {
+        name: "paragraph",
+        children: []
+      },
+      {
         name: "inlineAd1",
         children: []
       },
@@ -203,11 +211,11 @@ const contentWithAd = [
         name: "paragraph",
         children: []
       },
+      // 15th para
       {
         name: "paragraph",
         children: []
       },
-      // 15th para
       {
         name: "paragraph",
         children: []

--- a/packages/article-skeleton/fixtures/inline-ad.js
+++ b/packages/article-skeleton/fixtures/inline-ad.js
@@ -195,7 +195,6 @@ const contentWithAd = [
         name: "paragraph",
         children: []
       },
-     
       {
         name: "paragraph",
         children: []

--- a/packages/article-skeleton/fixtures/inline-ad.js
+++ b/packages/article-skeleton/fixtures/inline-ad.js
@@ -102,10 +102,6 @@ const contentWithOutAd = [
       {
         name: "paragraph",
         children: []
-      },
-      {
-        name: "paragraph",
-        children: []
       }
     ]
   }
@@ -192,13 +188,14 @@ const contentWithAd = [
         children: []
       },
       {
-        name: "paragraph",
-        children: []
-      },
-      {
         name: "inlineAd1",
         children: []
       },
+      {
+        name: "paragraph",
+        children: []
+      },
+     
       {
         name: "paragraph",
         children: []
@@ -212,10 +209,6 @@ const contentWithAd = [
         children: []
       },
       // 15th para
-      {
-        name: "paragraph",
-        children: []
-      },
       {
         name: "paragraph",
         children: []

--- a/packages/article-skeleton/src/contentModifiers/inline-ad.js
+++ b/packages/article-skeleton/src/contentModifiers/inline-ad.js
@@ -10,7 +10,9 @@ const insertInlineAd = children => {
   const paywallChildren = child.children;
   const paywallParagraphs = paywallChildren
     .map((item, index) => ({ ...item, index }))
-    .filter(item => item.name === "paragraph");
+    .filter(item => item.name === "paragraph")
+    .pop();
+
   const paraPostition = [10, 15, 20, 25];
 
   paraPostition.forEach((item, i) => {
@@ -21,7 +23,7 @@ const insertInlineAd = children => {
         : null;
 
       if (indexPos && indexPos !== null) {
-        paywallChildren.splice(indexPos + i, 0, {
+        paywallChildren.splice(indexPos + i + 1, 0, {
           name: `inlineAd${i + 1}`,
           children: []
         });

--- a/packages/article-skeleton/src/contentModifiers/inline-ad.js
+++ b/packages/article-skeleton/src/contentModifiers/inline-ad.js
@@ -15,7 +15,7 @@ const insertInlineAd = children => {
   // remove last paragraph to stop ads being appended to the end of the article
   paywallParagraphs.pop();
 
-  const paraPostition = [10, 15, 20, 25];
+  const paraPostition = [9, 14, 19, 24];
 
   paraPostition.forEach((item, i) => {
     const inlineAd = paywallChildren.find(ad => ad.name === `inlineAd${i + 1}`);

--- a/packages/article-skeleton/src/contentModifiers/inline-ad.js
+++ b/packages/article-skeleton/src/contentModifiers/inline-ad.js
@@ -10,8 +10,10 @@ const insertInlineAd = children => {
   const paywallChildren = child.children;
   const paywallParagraphs = paywallChildren
     .map((item, index) => ({ ...item, index }))
-    .filter(item => item.name === "paragraph")
-    .pop();
+    .filter(item => item.name === "paragraph");
+
+  // remove last paragraph to stop ads being appended to the end of the article
+  paywallParagraphs.pop();
 
   const paraPostition = [10, 15, 20, 25];
 

--- a/packages/article-skeleton/src/contentModifiers/inline-ad.js
+++ b/packages/article-skeleton/src/contentModifiers/inline-ad.js
@@ -15,6 +15,7 @@ const insertInlineAd = children => {
   // remove last paragraph to stop ads being appended to the end of the article
   paywallParagraphs.pop();
 
+  // insert AFTER these positions - so insert in positions 10, 15, 20, 25
   const paraPostition = [9, 14, 19, 24];
 
   paraPostition.forEach((item, i) => {


### PR DESCRIPTION
### Description

Update article ad positions from BEFORE paragraph (10 for example) to AFTER paragraph (9)

<img width="1031" alt="Screenshot 2024-07-26 at 10 46 46" src="https://github.com/user-attachments/assets/93ef8205-5fcd-4c1c-9350-f913f915c766">



### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
