### PR TITLE
feat(TMPZ-546): Puzzle sidebar headline Color should be updated

### DIFF
--- a/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -974,7 +974,7 @@ exports[`6. an article with puzzle sidebar 1`] = `
                   href="https://www.thetimes.co.uk/puzzles/crossword"
                 >
                   <img
-                    alt="Puzzle thumbnail"
+                    alt="Puzzle category thumbnail"
                     src="https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/crossword-c7ae8934ef.png"
                   />
                   <p>
@@ -984,7 +984,7 @@ exports[`6. an article with puzzle sidebar 1`] = `
                 <hr />
                 <a>
                   <img
-                    alt="Puzzle thumbnail"
+                    alt="Puzzle category thumbnail"
                     src="https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/polygon-875ea55487.png"
                   />
                   <p>
@@ -996,7 +996,7 @@ exports[`6. an article with puzzle sidebar 1`] = `
                   href="https://www.thetimes.co.uk/puzzles/sudoku"
                 >
                   <img
-                    alt="Puzzle thumbnail"
+                    alt="Puzzle category thumbnail"
                     src="https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/sudoku-ee2aea0209.png"
                   />
                   <p>

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -812,7 +812,7 @@ exports[`6. an article with puzzle sidebar 1`] = `
                     href="https://www.thetimes.co.uk/puzzles/crossword"
                   >
                     <img
-                      alt="Puzzle thumbnail"
+                      alt="Puzzle category thumbnail"
                       src="https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/crossword-c7ae8934ef.png"
                     />
                     <p>
@@ -822,7 +822,7 @@ exports[`6. an article with puzzle sidebar 1`] = `
                   <hr />
                   <a>
                     <img
-                      alt="Puzzle thumbnail"
+                      alt="Puzzle category thumbnail"
                       src="https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/polygon-875ea55487.png"
                     />
                     <p>
@@ -834,7 +834,7 @@ exports[`6. an article with puzzle sidebar 1`] = `
                     href="https://www.thetimes.co.uk/puzzles/sudoku"
                   >
                     <img
-                      alt="Puzzle thumbnail"
+                      alt="Puzzle category thumbnail"
                       src="https://www.thetimes.co.uk/d/img/puzzles/new-illustrations/sudoku-ee2aea0209.png"
                     />
                     <p>

--- a/packages/ts-components/src/components/article-sidebar/ArticleSidebar.tsx
+++ b/packages/ts-components/src/components/article-sidebar/ArticleSidebar.tsx
@@ -48,6 +48,7 @@ export const ArticleSidebar: FC<ArticleSideBarProps> = ({
 
       <Description>Challenge yourself with today’s puzzles.</Description>
       <Divider />
+
       {data.map(({ title, url, imgUrl }) => (
         <React.Fragment key={title}>
           <PuzzleContainer
@@ -61,7 +62,7 @@ export const ArticleSidebar: FC<ArticleSideBarProps> = ({
             }
             className="trigger-card-link"
           >
-            <PuzzleImage src={imgUrl} alt="Puzzle thumbnail" />
+            <PuzzleImage src={imgUrl} alt="Puzzle category thumbnail" />
             <ItemTitle>{title}</ItemTitle>
           </PuzzleContainer>
           <Divider />

--- a/packages/ts-components/src/components/article-sidebar/ArticleSidebar.tsx
+++ b/packages/ts-components/src/components/article-sidebar/ArticleSidebar.tsx
@@ -62,7 +62,7 @@ export const ArticleSidebar: FC<ArticleSideBarProps> = ({
             }
             className="trigger-card-link"
           >
-            <PuzzleImage src={imgUrl} alt="Puzzle thumbnail" />
+            <PuzzleImage src={imgUrl} alt="Puzzle category thumbnail" />
             <ItemTitle>{title}</ItemTitle>
           </PuzzleContainer>
           <Divider />

--- a/packages/ts-components/src/components/article-sidebar/ArticleSidebar.tsx
+++ b/packages/ts-components/src/components/article-sidebar/ArticleSidebar.tsx
@@ -48,7 +48,6 @@ export const ArticleSidebar: FC<ArticleSideBarProps> = ({
 
       <Description>Challenge yourself with today’s puzzles.</Description>
       <Divider />
-
       {data.map(({ title, url, imgUrl }) => (
         <React.Fragment key={title}>
           <PuzzleContainer
@@ -62,7 +61,7 @@ export const ArticleSidebar: FC<ArticleSideBarProps> = ({
             }
             className="trigger-card-link"
           >
-            <PuzzleImage src={imgUrl} alt="Puzzle category thumbnail" />
+            <PuzzleImage src={imgUrl} alt="Puzzle thumbnail" />
             <ItemTitle>{title}</ItemTitle>
           </PuzzleContainer>
           <Divider />

--- a/packages/ts-components/src/components/article-sidebar/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-components/src/components/article-sidebar/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`ArticleSidebar should render ArticleSidebar component 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bwzfXH kzdaiS"
+    class="sc-bwzfXH gYmlvh"
   >
     <a
-      class="trigger sc-ifAKCX kcwwi"
+      class="trigger sc-ifAKCX YFVti"
       href="https://www.thetimes.com/puzzles"
     >
       <div
@@ -18,7 +18,7 @@ exports[`ArticleSidebar should render ArticleSidebar component 1`] = `
           Puzzles for you
         </h3>
         <button
-          class="sc-gzVnrw ecbmwv"
+          class="sc-gzVnrw eoEpFe"
         >
           <svg
             aria-hidden="true"

--- a/packages/ts-components/src/components/article-sidebar/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-components/src/components/article-sidebar/__tests__/__snapshots__/index.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`ArticleSidebar should render ArticleSidebar component 1`] = `
       href="https://www.thetimes.com/puzzles/crossword"
     >
       <img
-        alt="Puzzle thumbnail"
+        alt="Puzzle category thumbnail"
         class="sc-iwsKbI elYeaz"
         src="https://www.thetimes.com/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0&resize=500"
       />
@@ -70,7 +70,7 @@ exports[`ArticleSidebar should render ArticleSidebar component 1`] = `
       href="https://www.thetimes.com/puzzles/sudoku"
     >
       <img
-        alt="Puzzle thumbnail"
+        alt="Puzzle category thumbnail"
         class="sc-iwsKbI elYeaz"
         src="https://www.thetimes.com/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0&resize=500"
       />

--- a/packages/ts-components/src/components/article-sidebar/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ts-components/src/components/article-sidebar/__tests__/__snapshots__/index.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`ArticleSidebar should render ArticleSidebar component 1`] = `
       href="https://www.thetimes.com/puzzles/crossword"
     >
       <img
-        alt="Puzzle category thumbnail"
+        alt="Puzzle thumbnail"
         class="sc-iwsKbI elYeaz"
         src="https://www.thetimes.com/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0&resize=500"
       />
@@ -70,7 +70,7 @@ exports[`ArticleSidebar should render ArticleSidebar component 1`] = `
       href="https://www.thetimes.com/puzzles/sudoku"
     >
       <img
-        alt="Puzzle category thumbnail"
+        alt="Puzzle thumbnail"
         class="sc-iwsKbI elYeaz"
         src="https://www.thetimes.com/imageserver/image/%2Fpuzzles%2Ficons%2F33b27655-dcc9-421f-906f-b2b10dd26865.png?crop=1250%2C833%2C0%2C0&resize=500"
       />

--- a/packages/ts-components/src/components/article-sidebar/styles.ts
+++ b/packages/ts-components/src/components/article-sidebar/styles.ts
@@ -11,7 +11,7 @@ export const Container = styled.div`
   padding-top: 12px;
   border-style: solid none none none;
   border-width: 3px;
-  border-color: #df7334;
+  border-color: #c05729;
 `;
 
 export const Description = styled.p`
@@ -47,7 +47,7 @@ export const Link = styled.a`
     }
   }
   h3 {
-    color: #df7334;
+    color: #c05729;
   }
 `;
 
@@ -68,7 +68,7 @@ export const Title = styled.h3`
 
 export const ChevronButton = styled.button`
   background-color: #eeeeee;
-  color: #df7334;
+  color: #c05729;
   border-radius: 50%;
   border: none;
   cursor: pointer;


### PR DESCRIPTION
### Description

Header color to match the brand color

[TMPZ-546](https://nidigitalsolutions.jira.com/browse/TMPZ-546)


### Checklist

- [X] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.


[TMPZ-546]: https://nidigitalsolutions.jira.com/browse/TMPZ-546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ