### PR TITLE
feat(TMD-1082): update to newsletter title within on click sign up com

### DIFF
--- a/packages/article-skeleton/fixtures/newsletter.js
+++ b/packages/article-skeleton/fixtures/newsletter.js
@@ -78,7 +78,7 @@ export const paywallContentWithNewsletter = {
           attributes: {
             label: "In your inbox",
             code: "TNL-101",
-            headline: "Best of Times",
+            headline: "Daily Briefing",
             copy:
               "We’ll send you our top stories, across all sections, straight to your inbox. Simple as that.",
             imageUri:

--- a/packages/article-skeleton/src/contentModifiers/newsletter-puff.js
+++ b/packages/article-skeleton/src/contentModifiers/newsletter-puff.js
@@ -19,7 +19,7 @@ const newslettersBySection = [
     section: "news",
     payload: setNewsletterPayload({
       code: "TNL-101",
-      headline: "Best of Times",
+      headline: "Daily Briefing",
       copy:
         "Our flagship newsletter featuring our top stories and analysis, delivered every morning.",
       imageUri:

--- a/packages/ts-components/src/components/newsletter-puff/NewsletterPuff.stories.tsx
+++ b/packages/ts-components/src/components/newsletter-puff/NewsletterPuff.stories.tsx
@@ -25,7 +25,7 @@ const mocks = [
         newsletter: {
           id: 'a2l6E000000CdHzQAK',
           isSubscribed: false,
-          title: 'Best of Times',
+          title: 'Daily Briefing',
           __typename: 'Newsletter'
         }
       }
@@ -46,7 +46,7 @@ const showcase = {
           >
             <AutoNewsletterPuff
               code={text('code', 'TNL-101')}
-              headline={text('headline', 'Best of Times')}
+              headline={text('headline', 'Daily Briefing')}
               copy={text(
                 'copy',
                 'We’ll send you our top stories, across all sections, straight to your inbox. Simple as that.'
@@ -72,7 +72,7 @@ const showcase = {
             <InlineNewsletterPuff
               section="news"
               code={text('code', 'TNL-101')}
-              headline={text('headline', 'Best of Times')}
+              headline={text('headline', 'Daily Briefing')}
               copy={text(
                 'copy',
                 'We’ll send you our top stories, across all sections, straight to your inbox. Simple as that.'
@@ -91,7 +91,7 @@ const showcase = {
       component: ({ text }: any) => (
         <PreviewNewsletterPuff
           section="sport"
-          headline={text('headline', 'Best of Times')}
+          headline={text('headline', 'Daily Briefing')}
           copy={text(
             'copy',
             'We’ll send you our top stories, across all sections, straight to your inbox. Simple as that.'

--- a/packages/ts-components/src/components/newsletter-puff/__tests__/AutoNewsletterPuff.test.tsx
+++ b/packages/ts-components/src/components/newsletter-puff/__tests__/AutoNewsletterPuff.test.tsx
@@ -27,7 +27,7 @@ const mocks = [
         newsletter: {
           id: 'a2l6E000000CdHzQAK',
           isSubscribed: false,
-          title: 'Best of Times',
+          title: 'Daily Briefing',
           __typename: 'Newsletter'
         }
       }


### PR DESCRIPTION
### Description

What
Update to the title of the Best of Times newsletter to Daily Briefing 

Why
The Best of Times newsletter has been rebranded to become the Daily Briefing

Scope
Automated on-click newsletter sign up component presented within articles

Technical Notes
Relevant notes that would be useful for any dev picking this story up

Design + QA Notes for handoff (To be filled in while on the board)
Any relevant design notes of what to test, build numbers, etc. as well as QA notes that should be called out before the story is move across the board

Component currently:

<img width="815" alt="Screenshot 2024-11-27 at 14 02 08" src="https://github.com/user-attachments/assets/28be6b9e-dfc2-4afa-8371-f3f33907d392">

Acceptance Criteria

The title now renders as Daily Briefing when the automated on-click newsletter sign up component is presented within articles 

[JIRA-1082](https://nidigitalsolutions.jira.com/browse/TMD-1082)


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/989c9481-e041-4bde-bf64-4b2eca5ecd2b)

