### PR TITLE
fix(TMRS-586): add heights to opta widgets

### DIFF
--- a/packages/ts-components/src/components/opta/cricket/scorecard/OptaCricketScorecard.stories.tsx
+++ b/packages/ts-components/src/components/opta/cricket/scorecard/OptaCricketScorecard.stories.tsx
@@ -21,9 +21,9 @@ const showcase = {
     },
     {
       component: () => (
-        <OptaCricketScorecard competition="3071" match="55391" />
+        <OptaCricketScorecard competition="3071" match="55391" height={905} />
       ),
-      name: 'Scorecard (1st inns)',
+      name: 'Scorecard (1st inns) with set height',
       type: 'story'
     }
   ],

--- a/packages/ts-components/src/components/opta/cricket/scorecard/OptaCricketScorecard.tsx
+++ b/packages/ts-components/src/components/opta/cricket/scorecard/OptaCricketScorecard.tsx
@@ -17,7 +17,8 @@ export const OptaCricketScorecard: React.FC<{
   competition: string;
   match: string;
   full_width?: boolean;
-}> = React.memo(({ competition, match, full_width }) => {
+  height?: number;
+}> = React.memo(({ competition, match, full_width, height }) => {
   const ref = React.createRef<HTMLDivElement>();
 
   const [isReady, setIsReady] = useState<boolean>(false);
@@ -68,11 +69,11 @@ export const OptaCricketScorecard: React.FC<{
   }, []);
 
   return (
-    <Container border={isReady} fullWidth={full_width}>
+    <Container border={isReady} fullWidth={full_width} $height={height}>
       <WidgetContainer ref={ref} />
 
       {!isReady && (
-        <PlaceholderContainer>
+        <PlaceholderContainer height={height}>
           <Placeholder />
         </PlaceholderContainer>
       )}

--- a/packages/ts-components/src/components/opta/cricket/scorecard/__tests__/__snapshots__/OptaCricketScorecard.test.tsx.snap
+++ b/packages/ts-components/src/components/opta/cricket/scorecard/__tests__/__snapshots__/OptaCricketScorecard.test.tsx.snap
@@ -3,13 +3,13 @@
 exports[`OptaCricketScorecard should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa giUBsz"
+    class="sc-bdVaJa bpMxyE"
   >
     <div
       class="sc-htpNat sc-bxivhb cDDLep"
     />
     <div
-      class="sc-bwzfXH kVYHKf"
+      class="sc-bwzfXH iCdzAV"
     >
       Placeholder
     </div>
@@ -20,7 +20,7 @@ exports[`OptaCricketScorecard should render correctly 1`] = `
 exports[`OptaCricketScorecard should render correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa hGXeaj"
+    class="sc-bdVaJa bvHEsZ"
   >
     <div
       class="sc-htpNat sc-bxivhb cDDLep"

--- a/packages/ts-components/src/components/opta/cricket/scorecard/__tests__/__snapshots__/OptaCricketScorecard.test.tsx.snap
+++ b/packages/ts-components/src/components/opta/cricket/scorecard/__tests__/__snapshots__/OptaCricketScorecard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OptaCricketScorecard should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bpMxyE"
+    class="sc-bdVaJa laZDmH"
   >
     <div
       class="sc-htpNat sc-bxivhb cDDLep"
@@ -20,7 +20,7 @@ exports[`OptaCricketScorecard should render correctly 1`] = `
 exports[`OptaCricketScorecard should render correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bvHEsZ"
+    class="sc-bdVaJa Ssmqo"
   >
     <div
       class="sc-htpNat sc-bxivhb cDDLep"

--- a/packages/ts-components/src/components/opta/cricket/shared-styles.ts
+++ b/packages/ts-components/src/components/opta/cricket/shared-styles.ts
@@ -1,7 +1,12 @@
 import styled from 'styled-components';
 import { breakpoints, colours, fonts } from '@times-components/ts-styleguide';
 
-export const Container = styled.div<{ border: boolean; fullWidth?: boolean }>`
+export const Container = styled.div<{
+  border: boolean;
+  fullWidth?: boolean;
+  $height?: number;
+}>`
+  ${({ $height }) => $height && `height: ${$height}px;`}
   margin: 0 auto 20px auto;
   background-color: ${colours.functional.backgroundPrimary};
   border-top: ${({ border }) =>
@@ -21,9 +26,9 @@ export const Container = styled.div<{ border: boolean; fullWidth?: boolean }>`
   }
 `;
 
-export const PlaceholderContainer = styled.div`
+export const PlaceholderContainer = styled.div<{ height?: number }>`
+  height: ${({ height }) => height || '200'}px;
   position: relative;
-  height: 200px;
 `;
 
 export const WidgetContainerBase = styled.div`

--- a/packages/ts-components/src/components/opta/cricket/shared-styles.ts
+++ b/packages/ts-components/src/components/opta/cricket/shared-styles.ts
@@ -27,7 +27,7 @@ export const Container = styled.div<{
 `;
 
 export const PlaceholderContainer = styled.div<{ height?: number }>`
-  height: ${({ height }) => height || '200'}px;
+  height: ${({ height }) => height || 200}px;
   position: relative;
 `;
 

--- a/packages/ts-components/src/components/opta/cricket/shared-styles.ts
+++ b/packages/ts-components/src/components/opta/cricket/shared-styles.ts
@@ -6,8 +6,8 @@ export const Container = styled.div<{
   fullWidth?: boolean;
   $height?: number;
 }>`
-  ${({ $height }) => $height && `height: ${$height}px;`}
-  margin: 0 auto 20px auto;
+  ${({ $height }) =>
+    $height && `height: ${$height}px;`} margin: 0 auto 20px auto;
   background-color: ${colours.functional.backgroundPrimary};
   border-top: ${({ border }) =>
     border ? `2px solid ${colours.section.sport}` : 'none'};

--- a/packages/ts-components/src/components/opta/football/fixtures-tournament/__tests__/__snapshots__/OptaFootballFixturesTournament.test.tsx.snap
+++ b/packages/ts-components/src/components/opta/football/fixtures-tournament/__tests__/__snapshots__/OptaFootballFixturesTournament.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OptaFootballFixturesTournament should render full width correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bzdUzT"
+    class="sc-bdVaJa cUvRCq"
   >
     <div
       class="sc-htpNat sc-ifAKCX dniyMN team-flags"
@@ -20,7 +20,7 @@ exports[`OptaFootballFixturesTournament should render full width correctly 1`] =
 exports[`OptaFootballFixturesTournament should render full width correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa jODlXD"
+    class="sc-bdVaJa fJdfAz"
   >
     <div
       class="sc-htpNat sc-ifAKCX dniyMN team-flags"
@@ -36,7 +36,7 @@ exports[`OptaFootballFixturesTournament should render full width correctly 2`] =
 exports[`OptaFootballFixturesTournament should render national competitions correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa giUBsz"
+    class="sc-bdVaJa bpMxyE"
   >
     <div
       class="sc-htpNat sc-ifAKCX dniyMN team-flags"
@@ -53,7 +53,7 @@ exports[`OptaFootballFixturesTournament should render national competitions corr
 exports[`OptaFootballFixturesTournament should render national competitions correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa hGXeaj"
+    class="sc-bdVaJa bvHEsZ"
   >
     <div
       class="sc-htpNat sc-ifAKCX dniyMN team-flags"
@@ -69,7 +69,7 @@ exports[`OptaFootballFixturesTournament should render national competitions corr
 exports[`OptaFootballFixturesTournament should render national competitions correctly with single column 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa giUBsz"
+    class="sc-bdVaJa bpMxyE"
   >
     <div
       class="sc-htpNat sc-ifAKCX UELGY team-flags"
@@ -86,7 +86,7 @@ exports[`OptaFootballFixturesTournament should render national competitions corr
 exports[`OptaFootballFixturesTournament should render national competitions correctly with single column 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa hGXeaj"
+    class="sc-bdVaJa bvHEsZ"
   >
     <div
       class="sc-htpNat sc-ifAKCX UELGY team-flags"
@@ -102,7 +102,7 @@ exports[`OptaFootballFixturesTournament should render national competitions corr
 exports[`OptaFootballFixturesTournament should render other competitions correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa giUBsz"
+    class="sc-bdVaJa bpMxyE"
   >
     <div
       class="sc-htpNat sc-ifAKCX bqOljm"
@@ -119,7 +119,7 @@ exports[`OptaFootballFixturesTournament should render other competitions correct
 exports[`OptaFootballFixturesTournament should render other competitions correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa hGXeaj"
+    class="sc-bdVaJa bvHEsZ"
   >
     <div
       class="sc-htpNat sc-ifAKCX bqOljm"

--- a/packages/ts-components/src/components/opta/football/fixtures-tournament/__tests__/__snapshots__/OptaFootballFixturesTournament.test.tsx.snap
+++ b/packages/ts-components/src/components/opta/football/fixtures-tournament/__tests__/__snapshots__/OptaFootballFixturesTournament.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OptaFootballFixturesTournament should render full width correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa cUvRCq"
+    class="sc-bdVaJa gCTnDg"
   >
     <div
       class="sc-htpNat sc-ifAKCX dniyMN team-flags"
@@ -20,7 +20,7 @@ exports[`OptaFootballFixturesTournament should render full width correctly 1`] =
 exports[`OptaFootballFixturesTournament should render full width correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa fJdfAz"
+    class="sc-bdVaJa ecgEcY"
   >
     <div
       class="sc-htpNat sc-ifAKCX dniyMN team-flags"
@@ -36,7 +36,7 @@ exports[`OptaFootballFixturesTournament should render full width correctly 2`] =
 exports[`OptaFootballFixturesTournament should render national competitions correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bpMxyE"
+    class="sc-bdVaJa laZDmH"
   >
     <div
       class="sc-htpNat sc-ifAKCX dniyMN team-flags"
@@ -53,7 +53,7 @@ exports[`OptaFootballFixturesTournament should render national competitions corr
 exports[`OptaFootballFixturesTournament should render national competitions correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bvHEsZ"
+    class="sc-bdVaJa Ssmqo"
   >
     <div
       class="sc-htpNat sc-ifAKCX dniyMN team-flags"
@@ -69,7 +69,7 @@ exports[`OptaFootballFixturesTournament should render national competitions corr
 exports[`OptaFootballFixturesTournament should render national competitions correctly with single column 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bpMxyE"
+    class="sc-bdVaJa laZDmH"
   >
     <div
       class="sc-htpNat sc-ifAKCX UELGY team-flags"
@@ -86,7 +86,7 @@ exports[`OptaFootballFixturesTournament should render national competitions corr
 exports[`OptaFootballFixturesTournament should render national competitions correctly with single column 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bvHEsZ"
+    class="sc-bdVaJa Ssmqo"
   >
     <div
       class="sc-htpNat sc-ifAKCX UELGY team-flags"
@@ -102,7 +102,7 @@ exports[`OptaFootballFixturesTournament should render national competitions corr
 exports[`OptaFootballFixturesTournament should render other competitions correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bpMxyE"
+    class="sc-bdVaJa laZDmH"
   >
     <div
       class="sc-htpNat sc-ifAKCX bqOljm"
@@ -119,7 +119,7 @@ exports[`OptaFootballFixturesTournament should render other competitions correct
 exports[`OptaFootballFixturesTournament should render other competitions correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bvHEsZ"
+    class="sc-bdVaJa Ssmqo"
   >
     <div
       class="sc-htpNat sc-ifAKCX bqOljm"

--- a/packages/ts-components/src/components/opta/football/fixtures/__tests__/__snapshots__/OptaFootballFixtures.test.tsx.snap
+++ b/packages/ts-components/src/components/opta/football/fixtures/__tests__/__snapshots__/OptaFootballFixtures.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OptaFootballFixtures should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa giUBsz"
+    class="sc-bdVaJa bpMxyE"
   >
     <div
       class="sc-htpNat sc-ifAKCX kRuyQz"
@@ -20,7 +20,7 @@ exports[`OptaFootballFixtures should render correctly 1`] = `
 exports[`OptaFootballFixtures should render correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa hGXeaj"
+    class="sc-bdVaJa bvHEsZ"
   >
     <div
       class="sc-htpNat sc-ifAKCX kRuyQz"

--- a/packages/ts-components/src/components/opta/football/fixtures/__tests__/__snapshots__/OptaFootballFixtures.test.tsx.snap
+++ b/packages/ts-components/src/components/opta/football/fixtures/__tests__/__snapshots__/OptaFootballFixtures.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OptaFootballFixtures should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bpMxyE"
+    class="sc-bdVaJa laZDmH"
   >
     <div
       class="sc-htpNat sc-ifAKCX kRuyQz"
@@ -20,7 +20,7 @@ exports[`OptaFootballFixtures should render correctly 1`] = `
 exports[`OptaFootballFixtures should render correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bvHEsZ"
+    class="sc-bdVaJa Ssmqo"
   >
     <div
       class="sc-htpNat sc-ifAKCX kRuyQz"

--- a/packages/ts-components/src/components/opta/football/match-stats/OptaFootballMatchStats.tsx
+++ b/packages/ts-components/src/components/opta/football/match-stats/OptaFootballMatchStats.tsx
@@ -18,7 +18,8 @@ export const OptaFootballMatchStats: React.FC<{
   competition: string;
   match: string;
   full_width?: boolean;
-}> = React.memo(({ season, competition, match, full_width }) => {
+  height?: number;
+}> = React.memo(({ season, competition, match, full_width, height = 640 }) => {
   const ref = React.createRef<HTMLDivElement>();
 
   const [isReady, setIsReady] = useState<boolean>(false);
@@ -58,11 +59,11 @@ export const OptaFootballMatchStats: React.FC<{
   }, []);
 
   return (
-    <Container border={isReady} fullWidth={full_width}>
+    <Container border={isReady} fullWidth={full_width} $height={height}>
       <WidgetContainer ref={ref} />
 
       {!isReady && (
-        <PlaceholderContainer>
+        <PlaceholderContainer height={height}>
           <Placeholder />
         </PlaceholderContainer>
       )}

--- a/packages/ts-components/src/components/opta/football/match-stats/__tests__/__snapshots__/OptaFootballMatchStats.test.tsx.snap
+++ b/packages/ts-components/src/components/opta/football/match-stats/__tests__/__snapshots__/OptaFootballMatchStats.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OptaFootballMatchStats should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa hvQJWg"
+    class="sc-bdVaJa fmzSUJ"
   >
     <div
       class="sc-htpNat sc-bxivhb deUMuZ"
@@ -21,7 +21,7 @@ exports[`OptaFootballMatchStats should render correctly 1`] = `
 exports[`OptaFootballMatchStats should render correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa jnmTre"
+    class="sc-bdVaJa jRWzmN"
   >
     <div
       class="sc-htpNat sc-bxivhb deUMuZ"

--- a/packages/ts-components/src/components/opta/football/match-stats/__tests__/__snapshots__/OptaFootballMatchStats.test.tsx.snap
+++ b/packages/ts-components/src/components/opta/football/match-stats/__tests__/__snapshots__/OptaFootballMatchStats.test.tsx.snap
@@ -3,13 +3,14 @@
 exports[`OptaFootballMatchStats should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa giUBsz"
+    class="sc-bdVaJa hvQJWg"
   >
     <div
       class="sc-htpNat sc-bxivhb deUMuZ"
     />
     <div
-      class="sc-bwzfXH kVYHKf"
+      class="sc-bwzfXH bpOSjf"
+      height="640"
     >
       Placeholder
     </div>
@@ -20,7 +21,7 @@ exports[`OptaFootballMatchStats should render correctly 1`] = `
 exports[`OptaFootballMatchStats should render correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa hGXeaj"
+    class="sc-bdVaJa jnmTre"
   >
     <div
       class="sc-htpNat sc-bxivhb deUMuZ"

--- a/packages/ts-components/src/components/opta/football/player-stats/OptaFootballPlayerStats.tsx
+++ b/packages/ts-components/src/components/opta/football/player-stats/OptaFootballPlayerStats.tsx
@@ -7,7 +7,7 @@ import {
   initStyleSheet,
   initScript,
   initElement,
-  initComponent,
+  initComponent
 } from '../../utils/config';
 
 import { Container, PlaceholderContainer } from '../shared-styles';
@@ -33,46 +33,49 @@ export const OptaFootballPlayerStats: React.FC<{
     show_title = true,
     visible_categories,
     classes,
-    height,
+    height
   }) => {
     const ref = React.createRef<HTMLDivElement>();
 
     const [isReady, setIsReady] = useState<boolean>(false);
     const isNationalComp = isNationalCompetition(competition);
 
-    useEffect(() => {
-      const sport = 'football';
+    useEffect(
+      () => {
+        const sport = 'football';
 
-      initSettings();
-      initStyleSheet(sport);
+        initSettings();
+        initStyleSheet(sport);
 
-      initScript().then(() => {
-        if (ref.current) {
-          ref.current.innerHTML = initElement('opta-widget', {
-            sport,
-            widget: 'player_ranking',
-            hide_zeroes,
-            season,
-            competition,
-            template: 'normal',
-            graph_style: 'relative',
-            visible_categories,
-            live: true,
-            show_match_header: true,
-            show_halftime_score: true,
-            show_competition_name: true,
-            show_date: true,
-            show_crests: true,
-            show_title,
-            date_format: 'DD/MM/YYYY',
-            breakpoints: '200',
-          }).outerHTML;
+        initScript().then(() => {
+          if (ref.current) {
+            ref.current.innerHTML = initElement('opta-widget', {
+              sport,
+              widget: 'player_ranking',
+              hide_zeroes,
+              season,
+              competition,
+              template: 'normal',
+              graph_style: 'relative',
+              visible_categories,
+              live: true,
+              show_match_header: true,
+              show_halftime_score: true,
+              show_competition_name: true,
+              show_date: true,
+              show_crests: true,
+              show_title,
+              date_format: 'DD/MM/YYYY',
+              breakpoints: '200'
+            }).outerHTML;
 
-          initComponent();
-          setIsReady(true);
-        }
-      });
-    }, [ref]);
+            initComponent();
+            setIsReady(true);
+          }
+        });
+      },
+      [ref]
+    );
 
     isNationalComp && useUpdateNationalTeamDetails(ref, 'Opta-Image-Team');
 

--- a/packages/ts-components/src/components/opta/football/player-stats/OptaFootballPlayerStats.tsx
+++ b/packages/ts-components/src/components/opta/football/player-stats/OptaFootballPlayerStats.tsx
@@ -7,7 +7,7 @@ import {
   initStyleSheet,
   initScript,
   initElement,
-  initComponent
+  initComponent,
 } from '../../utils/config';
 
 import { Container, PlaceholderContainer } from '../shared-styles';
@@ -23,6 +23,7 @@ export const OptaFootballPlayerStats: React.FC<{
   hide_zeroes?: boolean;
   show_title?: boolean;
   full_width?: boolean;
+  height?: number;
 }> = React.memo(
   ({
     season,
@@ -31,58 +32,61 @@ export const OptaFootballPlayerStats: React.FC<{
     hide_zeroes = true,
     show_title = true,
     visible_categories,
-    classes
+    classes,
+    height,
   }) => {
     const ref = React.createRef<HTMLDivElement>();
 
     const [isReady, setIsReady] = useState<boolean>(false);
     const isNationalComp = isNationalCompetition(competition);
 
-    useEffect(
-      () => {
-        const sport = 'football';
+    useEffect(() => {
+      const sport = 'football';
 
-        initSettings();
-        initStyleSheet(sport);
+      initSettings();
+      initStyleSheet(sport);
 
-        initScript().then(() => {
-          if (ref.current) {
-            ref.current.innerHTML = initElement('opta-widget', {
-              sport,
-              widget: 'player_ranking',
-              hide_zeroes,
-              season,
-              competition,
-              template: 'normal',
-              graph_style: 'relative',
-              visible_categories,
-              live: true,
-              show_match_header: true,
-              show_halftime_score: true,
-              show_competition_name: true,
-              show_date: true,
-              show_crests: true,
-              show_title,
-              date_format: 'DD/MM/YYYY',
-              breakpoints: '200'
-            }).outerHTML;
+      initScript().then(() => {
+        if (ref.current) {
+          ref.current.innerHTML = initElement('opta-widget', {
+            sport,
+            widget: 'player_ranking',
+            hide_zeroes,
+            season,
+            competition,
+            template: 'normal',
+            graph_style: 'relative',
+            visible_categories,
+            live: true,
+            show_match_header: true,
+            show_halftime_score: true,
+            show_competition_name: true,
+            show_date: true,
+            show_crests: true,
+            show_title,
+            date_format: 'DD/MM/YYYY',
+            breakpoints: '200',
+          }).outerHTML;
 
-            initComponent();
-            setIsReady(true);
-          }
-        });
-      },
-      [ref]
-    );
+          initComponent();
+          setIsReady(true);
+        }
+      });
+    }, [ref]);
 
     isNationalComp && useUpdateNationalTeamDetails(ref, 'Opta-Image-Team');
 
     return (
-      <Container border={isReady} fullWidth={full_width} className={classes}>
+      <Container
+        border={isReady}
+        fullWidth={full_width}
+        className={classes}
+        $height={height}
+      >
         <WidgetContainer ref={ref} />
 
         {!isReady && (
-          <PlaceholderContainer>
+          <PlaceholderContainer height={height}>
             <Placeholder />
           </PlaceholderContainer>
         )}

--- a/packages/ts-components/src/components/opta/football/player-stats/__tests__/__snapshots__/OptaFootballPlayerStats.test.tsx.snap
+++ b/packages/ts-components/src/components/opta/football/player-stats/__tests__/__snapshots__/OptaFootballPlayerStats.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OptaFootballPlayerStats should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa giUBsz"
+    class="sc-bdVaJa bpMxyE"
   >
     <div
       class="sc-htpNat sc-bxivhb deUMuZ team-flags"
@@ -20,7 +20,7 @@ exports[`OptaFootballPlayerStats should render correctly 1`] = `
 exports[`OptaFootballPlayerStats should render correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa hGXeaj"
+    class="sc-bdVaJa bvHEsZ"
   >
     <div
       class="sc-htpNat sc-bxivhb deUMuZ team-flags"

--- a/packages/ts-components/src/components/opta/football/player-stats/__tests__/__snapshots__/OptaFootballPlayerStats.test.tsx.snap
+++ b/packages/ts-components/src/components/opta/football/player-stats/__tests__/__snapshots__/OptaFootballPlayerStats.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OptaFootballPlayerStats should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bpMxyE"
+    class="sc-bdVaJa laZDmH"
   >
     <div
       class="sc-htpNat sc-bxivhb deUMuZ team-flags"
@@ -20,7 +20,7 @@ exports[`OptaFootballPlayerStats should render correctly 1`] = `
 exports[`OptaFootballPlayerStats should render correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bvHEsZ"
+    class="sc-bdVaJa Ssmqo"
   >
     <div
       class="sc-htpNat sc-bxivhb deUMuZ team-flags"

--- a/packages/ts-components/src/components/opta/football/shared-styles.ts
+++ b/packages/ts-components/src/components/opta/football/shared-styles.ts
@@ -25,13 +25,15 @@ const countries: Record<string, string> = {
   '362': 'Turkey',
   '520': 'Georgia',
   '359': 'Portugal',
-  '367': 'CzechRep',
+  '367': 'CzechRep'
 };
 
 const flagStyles = Object.keys(countries).map(
   (countryCode: string) => `
   .Opta-Team-${countryCode} .Opta-Team, .Opta-Team-${countryCode}.Opta-Team, .Opta-Player .Opta-Image-Team-${countryCode} {
-    background-image: url(https://extras.thetimes.co.uk/web/opta/euro-flags/${countries[countryCode]}.svg);
+    background-image: url(https://extras.thetimes.co.uk/web/opta/euro-flags/${
+      countries[countryCode]
+    }.svg);
     background-size: 20px;
     background-repeat: no-repeat;
   }
@@ -84,8 +86,8 @@ export const Container = styled.div<{
   fullWidth?: boolean;
   $height?: number;
 }>`
-  ${({ $height }) => $height && `height: ${$height}px;`}
-  margin: 0 auto 20px auto;
+  ${({ $height }) =>
+    $height && `height: ${$height}px;`} margin: 0 auto 20px auto;
   background-color: ${colours.functional.backgroundPrimary};
   border-top: ${({ border }) =>
     border ? `2px solid ${colours.section.sport}` : 'none'};

--- a/packages/ts-components/src/components/opta/football/shared-styles.ts
+++ b/packages/ts-components/src/components/opta/football/shared-styles.ts
@@ -25,15 +25,13 @@ const countries: Record<string, string> = {
   '362': 'Turkey',
   '520': 'Georgia',
   '359': 'Portugal',
-  '367': 'CzechRep'
+  '367': 'CzechRep',
 };
 
 const flagStyles = Object.keys(countries).map(
   (countryCode: string) => `
   .Opta-Team-${countryCode} .Opta-Team, .Opta-Team-${countryCode}.Opta-Team, .Opta-Player .Opta-Image-Team-${countryCode} {
-    background-image: url(https://extras.thetimes.co.uk/web/opta/euro-flags/${
-      countries[countryCode]
-    }.svg);
+    background-image: url(https://extras.thetimes.co.uk/web/opta/euro-flags/${countries[countryCode]}.svg);
     background-size: 20px;
     background-repeat: no-repeat;
   }
@@ -81,7 +79,12 @@ const flagStyles = Object.keys(countries).map(
 `
 );
 
-export const Container = styled.div<{ border: boolean; fullWidth?: boolean }>`
+export const Container = styled.div<{
+  border: boolean;
+  fullWidth?: boolean;
+  $height?: number;
+}>`
+  ${({ $height }) => $height && `height: ${$height}px;`}
   margin: 0 auto 20px auto;
   background-color: ${colours.functional.backgroundPrimary};
   border-top: ${({ border }) =>

--- a/packages/ts-components/src/components/opta/football/standings/OptaFootballStandings.stories.tsx
+++ b/packages/ts-components/src/components/opta/football/standings/OptaFootballStandings.stories.tsx
@@ -18,6 +18,11 @@ const showcase = {
       type: 'story'
     },
     {
+      component: () => <OptaFootballStandings season="2024" competition="10" height={1057} />,
+      name: 'Standings (with height)',
+      type: 'story'
+    },
+    {
       component: () => (
         <OptaFootballStandings
           season="2023"

--- a/packages/ts-components/src/components/opta/football/standings/OptaFootballStandings.stories.tsx
+++ b/packages/ts-components/src/components/opta/football/standings/OptaFootballStandings.stories.tsx
@@ -18,7 +18,9 @@ const showcase = {
       type: 'story'
     },
     {
-      component: () => <OptaFootballStandings season="2024" competition="10" height={1057} />,
+      component: () => (
+        <OptaFootballStandings season="2024" competition="10" height={1057} />
+      ),
       name: 'Standings (with height)',
       type: 'story'
     },

--- a/packages/ts-components/src/components/opta/football/standings/OptaFootballStandings.tsx
+++ b/packages/ts-components/src/components/opta/football/standings/OptaFootballStandings.tsx
@@ -7,7 +7,7 @@ import {
   initStyleSheet,
   initScript,
   initElement,
-  initComponent
+  initComponent,
 } from '../../utils/config';
 
 import { Container, PlaceholderContainer } from '../shared-styles';
@@ -24,6 +24,7 @@ export const OptaFootballStandings: React.FC<{
   full_width?: boolean;
   show_title?: boolean;
   columns?: boolean;
+  height?: number;
 }> = React.memo(
   ({
     season,
@@ -33,7 +34,8 @@ export const OptaFootballStandings: React.FC<{
     navigation,
     show_title = true,
     full_width,
-    columns
+    columns,
+    height,
   }) => {
     const ref = React.createRef<HTMLDivElement>();
 
@@ -59,7 +61,7 @@ export const OptaFootballStandings: React.FC<{
             show_title,
             show_crests: !isNationalComp,
             team_naming: 'brief',
-            breakpoints: 520
+            breakpoints: 520,
           }).outerHTML;
 
           initComponent();
@@ -71,11 +73,16 @@ export const OptaFootballStandings: React.FC<{
     isNationalComp && useUpdateNationalTeamDetails(ref, 'Opta-Team');
 
     return (
-      <Container border={isReady} fullWidth={full_width} className={classes}>
+      <Container
+        border={isReady}
+        fullWidth={full_width}
+        className={classes}
+        $height={height}
+      >
         <WidgetContainer ref={ref} columns={columns} />
 
         {!isReady && (
-          <PlaceholderContainer>
+          <PlaceholderContainer height={height}>
             <Placeholder />
           </PlaceholderContainer>
         )}

--- a/packages/ts-components/src/components/opta/football/standings/OptaFootballStandings.tsx
+++ b/packages/ts-components/src/components/opta/football/standings/OptaFootballStandings.tsx
@@ -7,7 +7,7 @@ import {
   initStyleSheet,
   initScript,
   initElement,
-  initComponent,
+  initComponent
 } from '../../utils/config';
 
 import { Container, PlaceholderContainer } from '../shared-styles';
@@ -35,7 +35,7 @@ export const OptaFootballStandings: React.FC<{
     show_title = true,
     full_width,
     columns,
-    height,
+    height
   }) => {
     const ref = React.createRef<HTMLDivElement>();
 
@@ -61,7 +61,7 @@ export const OptaFootballStandings: React.FC<{
             show_title,
             show_crests: !isNationalComp,
             team_naming: 'brief',
-            breakpoints: 520,
+            breakpoints: 520
           }).outerHTML;
 
           initComponent();

--- a/packages/ts-components/src/components/opta/football/standings/__tests__/__snapshots__/OptaFootballStandings.test.tsx.snap
+++ b/packages/ts-components/src/components/opta/football/standings/__tests__/__snapshots__/OptaFootballStandings.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OptaFootballStandings should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bpMxyE"
+    class="sc-bdVaJa laZDmH"
   >
     <div
       class="sc-htpNat sc-bxivhb gJKBih team-flags"
@@ -20,7 +20,7 @@ exports[`OptaFootballStandings should render correctly 1`] = `
 exports[`OptaFootballStandings should render correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bvHEsZ"
+    class="sc-bdVaJa Ssmqo"
   >
     <div
       class="sc-htpNat sc-bxivhb gJKBih team-flags"
@@ -36,7 +36,7 @@ exports[`OptaFootballStandings should render correctly 2`] = `
 exports[`OptaFootballStandings should render correctly, with columns 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bpMxyE"
+    class="sc-bdVaJa laZDmH"
   >
     <div
       class="sc-htpNat sc-bxivhb jPAjPs team-flags"
@@ -53,7 +53,7 @@ exports[`OptaFootballStandings should render correctly, with columns 1`] = `
 exports[`OptaFootballStandings should render correctly, with columns 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bvHEsZ"
+    class="sc-bdVaJa Ssmqo"
   >
     <div
       class="sc-htpNat sc-bxivhb jPAjPs team-flags"

--- a/packages/ts-components/src/components/opta/football/standings/__tests__/__snapshots__/OptaFootballStandings.test.tsx.snap
+++ b/packages/ts-components/src/components/opta/football/standings/__tests__/__snapshots__/OptaFootballStandings.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OptaFootballStandings should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa giUBsz"
+    class="sc-bdVaJa bpMxyE"
   >
     <div
       class="sc-htpNat sc-bxivhb gJKBih team-flags"
@@ -20,7 +20,7 @@ exports[`OptaFootballStandings should render correctly 1`] = `
 exports[`OptaFootballStandings should render correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa hGXeaj"
+    class="sc-bdVaJa bvHEsZ"
   >
     <div
       class="sc-htpNat sc-bxivhb gJKBih team-flags"
@@ -36,7 +36,7 @@ exports[`OptaFootballStandings should render correctly 2`] = `
 exports[`OptaFootballStandings should render correctly, with columns 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa giUBsz"
+    class="sc-bdVaJa bpMxyE"
   >
     <div
       class="sc-htpNat sc-bxivhb jPAjPs team-flags"
@@ -53,7 +53,7 @@ exports[`OptaFootballStandings should render correctly, with columns 1`] = `
 exports[`OptaFootballStandings should render correctly, with columns 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa hGXeaj"
+    class="sc-bdVaJa bvHEsZ"
   >
     <div
       class="sc-htpNat sc-bxivhb jPAjPs team-flags"

--- a/packages/ts-components/src/components/opta/football/summary/__tests__/__snapshots__/OptaFootballSummary.test.tsx.snap
+++ b/packages/ts-components/src/components/opta/football/summary/__tests__/__snapshots__/OptaFootballSummary.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OptaFootballSummary should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa giUBsz"
+    class="sc-bdVaJa bpMxyE"
   >
     <div
       class="sc-htpNat sc-bxivhb kRDlKQ"
@@ -20,7 +20,7 @@ exports[`OptaFootballSummary should render correctly 1`] = `
 exports[`OptaFootballSummary should render correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa hGXeaj"
+    class="sc-bdVaJa bvHEsZ"
   >
     <div
       class="sc-htpNat sc-bxivhb kRDlKQ"

--- a/packages/ts-components/src/components/opta/football/summary/__tests__/__snapshots__/OptaFootballSummary.test.tsx.snap
+++ b/packages/ts-components/src/components/opta/football/summary/__tests__/__snapshots__/OptaFootballSummary.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OptaFootballSummary should render correctly 1`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bpMxyE"
+    class="sc-bdVaJa laZDmH"
   >
     <div
       class="sc-htpNat sc-bxivhb kRDlKQ"
@@ -20,7 +20,7 @@ exports[`OptaFootballSummary should render correctly 1`] = `
 exports[`OptaFootballSummary should render correctly 2`] = `
 <DocumentFragment>
   <div
-    class="sc-bdVaJa bvHEsZ"
+    class="sc-bdVaJa Ssmqo"
   >
     <div
       class="sc-htpNat sc-bxivhb kRDlKQ"


### PR DESCRIPTION
### Description
- Height attribute added to OPTA widgets. Where this is fixed, as with the `OptaFootballFixturesTicker` the height has been entered as the default value.
- Support for breakpoint specific `height` attributes have been added to our iframe component;
e.g. 
```
attributes: {
  ...
  height: {
    xs: number;
    sm: number;
    md: number;
    lg: number;
  }
}
```
NB: These height values will need to be configured in NewsPress for use in articles.

[TMRS-586](https://nidigitalsolutions.jira.com/browse/TMRS-586)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.


[TMRS-586]: https://nidigitalsolutions.jira.com/browse/TMRS-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ