### PR TITLE
fix(TMD-1221): update newsletter puff loading

### DIFF
--- a/packages/ts-components/src/components/newsletter-puff/InlineNewsletterPuff.tsx
+++ b/packages/ts-components/src/components/newsletter-puff/InlineNewsletterPuff.tsx
@@ -39,7 +39,7 @@ export const InlineNewsletterPuff = ({
 
         if (isLoading || !newsletter) {
           return (
-            <InpContainer style={{ height: 257 }}>
+            <InpContainer>
               <Placeholder />
             </InpContainer>
           );

--- a/packages/ts-components/src/components/newsletter-puff/__tests__/__snapshots__/AutoNewsletterPuff.test.tsx.snap
+++ b/packages/ts-components/src/components/newsletter-puff/__tests__/__snapshots__/AutoNewsletterPuff.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<AutoNewsletterPuff> display function always renders 1`] = `
   style="display: block;"
 >
   <div
-    class="sc-htpNat sc-ifAKCX kDQZra"
+    class="sc-htpNat sc-ifAKCX kjWTLC"
   >
     <div
       class="tc-view__TcView-nuazoi-0 fPjBcr"
@@ -44,7 +44,7 @@ exports[`<AutoNewsletterPuff> display function doesnt render without consent 1`]
   style="display: none;"
 >
   <div
-    class="sc-htpNat sc-ifAKCX kDQZra"
+    class="sc-htpNat sc-ifAKCX kjWTLC"
   >
     <div
       class="tc-view__TcView-nuazoi-0 fPjBcr"
@@ -82,7 +82,7 @@ exports[`<AutoNewsletterPuff> using a display function [1, 3] count = 1 1`] = `
   style="display: block;"
 >
   <div
-    class="sc-htpNat sc-ifAKCX kDQZra"
+    class="sc-htpNat sc-ifAKCX kjWTLC"
   >
     <div
       class="tc-view__TcView-nuazoi-0 fPjBcr"
@@ -120,7 +120,7 @@ exports[`<AutoNewsletterPuff> using a display function [1, 3] count = 2 1`] = `
   style="display: none;"
 >
   <div
-    class="sc-htpNat sc-ifAKCX kDQZra"
+    class="sc-htpNat sc-ifAKCX kjWTLC"
   >
     <div
       class="tc-view__TcView-nuazoi-0 fPjBcr"

--- a/packages/ts-components/src/components/newsletter-puff/__tests__/__snapshots__/AutoNewsletterPuff.test.tsx.snap
+++ b/packages/ts-components/src/components/newsletter-puff/__tests__/__snapshots__/AutoNewsletterPuff.test.tsx.snap
@@ -6,8 +6,7 @@ exports[`<AutoNewsletterPuff> display function always renders 1`] = `
   style="display: block;"
 >
   <div
-    class="sc-htpNat sc-ifAKCX kVAWuv"
-    style="height: 257px;"
+    class="sc-htpNat sc-ifAKCX kjWTLC"
   >
     <div
       class="tc-view__TcView-nuazoi-0 fPjBcr"
@@ -45,8 +44,7 @@ exports[`<AutoNewsletterPuff> display function doesnt render without consent 1`]
   style="display: none;"
 >
   <div
-    class="sc-htpNat sc-ifAKCX kVAWuv"
-    style="height: 257px;"
+    class="sc-htpNat sc-ifAKCX kjWTLC"
   >
     <div
       class="tc-view__TcView-nuazoi-0 fPjBcr"
@@ -84,8 +82,7 @@ exports[`<AutoNewsletterPuff> using a display function [1, 3] count = 1 1`] = `
   style="display: block;"
 >
   <div
-    class="sc-htpNat sc-ifAKCX kVAWuv"
-    style="height: 257px;"
+    class="sc-htpNat sc-ifAKCX kjWTLC"
   >
     <div
       class="tc-view__TcView-nuazoi-0 fPjBcr"
@@ -123,8 +120,7 @@ exports[`<AutoNewsletterPuff> using a display function [1, 3] count = 2 1`] = `
   style="display: none;"
 >
   <div
-    class="sc-htpNat sc-ifAKCX kVAWuv"
-    style="height: 257px;"
+    class="sc-htpNat sc-ifAKCX kjWTLC"
   >
     <div
       class="tc-view__TcView-nuazoi-0 fPjBcr"

--- a/packages/ts-components/src/components/newsletter-puff/__tests__/__snapshots__/AutoNewsletterPuff.test.tsx.snap
+++ b/packages/ts-components/src/components/newsletter-puff/__tests__/__snapshots__/AutoNewsletterPuff.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<AutoNewsletterPuff> display function always renders 1`] = `
   style="display: block;"
 >
   <div
-    class="sc-htpNat sc-ifAKCX kjWTLC"
+    class="sc-htpNat sc-ifAKCX kDQZra"
   >
     <div
       class="tc-view__TcView-nuazoi-0 fPjBcr"
@@ -44,7 +44,7 @@ exports[`<AutoNewsletterPuff> display function doesnt render without consent 1`]
   style="display: none;"
 >
   <div
-    class="sc-htpNat sc-ifAKCX kjWTLC"
+    class="sc-htpNat sc-ifAKCX kDQZra"
   >
     <div
       class="tc-view__TcView-nuazoi-0 fPjBcr"
@@ -82,7 +82,7 @@ exports[`<AutoNewsletterPuff> using a display function [1, 3] count = 1 1`] = `
   style="display: block;"
 >
   <div
-    class="sc-htpNat sc-ifAKCX kjWTLC"
+    class="sc-htpNat sc-ifAKCX kDQZra"
   >
     <div
       class="tc-view__TcView-nuazoi-0 fPjBcr"
@@ -120,7 +120,7 @@ exports[`<AutoNewsletterPuff> using a display function [1, 3] count = 2 1`] = `
   style="display: none;"
 >
   <div
-    class="sc-htpNat sc-ifAKCX kjWTLC"
+    class="sc-htpNat sc-ifAKCX kDQZra"
   >
     <div
       class="tc-view__TcView-nuazoi-0 fPjBcr"

--- a/packages/ts-components/src/components/newsletter-puff/__tests__/__snapshots__/InlineNewsletterPuff.test.tsx.snap
+++ b/packages/ts-components/src/components/newsletter-puff/__tests__/__snapshots__/InlineNewsletterPuff.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Inline Newsletter Puff renders loading state state 1`] = `
 <body>
   <div>
     <div
-      class="sc-htpNat sc-ifAKCX iWYiTB"
+      class="sc-htpNat sc-ifAKCX eLTRXu"
     >
       <div
         class="sc-htpNat sc-dnqmqq duLROv"
@@ -54,8 +54,7 @@ exports[`Inline Newsletter Puff renders placeholder when loading 1`] = `
 <body>
   <div>
     <div
-      class="sc-htpNat sc-ifAKCX kVAWuv"
-      style="height: 257px;"
+      class="sc-htpNat sc-ifAKCX kjWTLC"
     >
       <div
         class="tc-view__TcView-nuazoi-0 fPjBcr"
@@ -92,7 +91,7 @@ exports[`Inline Newsletter Puff renders signup state 1`] = `
 <body>
   <div>
     <div
-      class="sc-htpNat sc-ifAKCX iWYiTB"
+      class="sc-htpNat sc-ifAKCX eLTRXu"
     >
       <div
         class="sc-htpNat sc-iwsKbI cuimXU"
@@ -136,7 +135,7 @@ exports[`Inline Newsletter Puff renders signup view when not already subscribed 
 <body>
   <div>
     <div
-      class="sc-htpNat sc-ifAKCX iWYiTB"
+      class="sc-htpNat sc-ifAKCX eLTRXu"
     >
       <div
         class="sc-htpNat sc-iwsKbI cuimXU"

--- a/packages/ts-components/src/components/newsletter-puff/__tests__/__snapshots__/InlineNewsletterPuff.test.tsx.snap
+++ b/packages/ts-components/src/components/newsletter-puff/__tests__/__snapshots__/InlineNewsletterPuff.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Inline Newsletter Puff renders loading state state 1`] = `
 <body>
   <div>
     <div
-      class="sc-htpNat sc-ifAKCX fChScq"
+      class="sc-htpNat sc-ifAKCX eLTRXu"
     >
       <div
         class="sc-htpNat sc-dnqmqq duLROv"
@@ -54,7 +54,7 @@ exports[`Inline Newsletter Puff renders placeholder when loading 1`] = `
 <body>
   <div>
     <div
-      class="sc-htpNat sc-ifAKCX kDQZra"
+      class="sc-htpNat sc-ifAKCX kjWTLC"
     >
       <div
         class="tc-view__TcView-nuazoi-0 fPjBcr"
@@ -91,7 +91,7 @@ exports[`Inline Newsletter Puff renders signup state 1`] = `
 <body>
   <div>
     <div
-      class="sc-htpNat sc-ifAKCX fChScq"
+      class="sc-htpNat sc-ifAKCX eLTRXu"
     >
       <div
         class="sc-htpNat sc-iwsKbI cuimXU"
@@ -135,7 +135,7 @@ exports[`Inline Newsletter Puff renders signup view when not already subscribed 
 <body>
   <div>
     <div
-      class="sc-htpNat sc-ifAKCX fChScq"
+      class="sc-htpNat sc-ifAKCX eLTRXu"
     >
       <div
         class="sc-htpNat sc-iwsKbI cuimXU"

--- a/packages/ts-components/src/components/newsletter-puff/__tests__/__snapshots__/InlineNewsletterPuff.test.tsx.snap
+++ b/packages/ts-components/src/components/newsletter-puff/__tests__/__snapshots__/InlineNewsletterPuff.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Inline Newsletter Puff renders loading state state 1`] = `
 <body>
   <div>
     <div
-      class="sc-htpNat sc-ifAKCX eLTRXu"
+      class="sc-htpNat sc-ifAKCX fChScq"
     >
       <div
         class="sc-htpNat sc-dnqmqq duLROv"
@@ -54,7 +54,7 @@ exports[`Inline Newsletter Puff renders placeholder when loading 1`] = `
 <body>
   <div>
     <div
-      class="sc-htpNat sc-ifAKCX kjWTLC"
+      class="sc-htpNat sc-ifAKCX kDQZra"
     >
       <div
         class="tc-view__TcView-nuazoi-0 fPjBcr"
@@ -91,7 +91,7 @@ exports[`Inline Newsletter Puff renders signup state 1`] = `
 <body>
   <div>
     <div
-      class="sc-htpNat sc-ifAKCX eLTRXu"
+      class="sc-htpNat sc-ifAKCX fChScq"
     >
       <div
         class="sc-htpNat sc-iwsKbI cuimXU"
@@ -135,7 +135,7 @@ exports[`Inline Newsletter Puff renders signup view when not already subscribed 
 <body>
   <div>
     <div
-      class="sc-htpNat sc-ifAKCX eLTRXu"
+      class="sc-htpNat sc-ifAKCX fChScq"
     >
       <div
         class="sc-htpNat sc-iwsKbI cuimXU"

--- a/packages/ts-components/src/components/newsletter-puff/preview-newsletter-puff/__tests__/__snapshots__/PreviewNewsletterPuff.test.tsx.snap
+++ b/packages/ts-components/src/components/newsletter-puff/preview-newsletter-puff/__tests__/__snapshots__/PreviewNewsletterPuff.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Preview Newsletter Puff renders 1`] = `
 <body>
   <div>
     <div
-      class="sc-bdVaJa sc-htpNat hdSiln"
+      class="sc-bdVaJa sc-htpNat eNCqrZ"
     >
       <div
         class="sc-bdVaJa sc-EHOje hmOAGx"

--- a/packages/ts-components/src/components/newsletter-puff/preview-newsletter-puff/__tests__/__snapshots__/PreviewNewsletterPuff.test.tsx.snap
+++ b/packages/ts-components/src/components/newsletter-puff/preview-newsletter-puff/__tests__/__snapshots__/PreviewNewsletterPuff.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Preview Newsletter Puff renders 1`] = `
 <body>
   <div>
     <div
-      class="sc-bdVaJa sc-htpNat ljXtVU"
+      class="sc-bdVaJa sc-htpNat hdSiln"
     >
       <div
         class="sc-bdVaJa sc-EHOje hmOAGx"

--- a/packages/ts-components/src/components/newsletter-puff/preview-newsletter-puff/__tests__/__snapshots__/PreviewNewsletterPuff.test.tsx.snap
+++ b/packages/ts-components/src/components/newsletter-puff/preview-newsletter-puff/__tests__/__snapshots__/PreviewNewsletterPuff.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Preview Newsletter Puff renders 1`] = `
 <body>
   <div>
     <div
-      class="sc-bdVaJa sc-htpNat eNCqrZ"
+      class="sc-bdVaJa sc-htpNat hdSiln"
     >
       <div
         class="sc-bdVaJa sc-EHOje hmOAGx"

--- a/packages/ts-components/src/components/newsletter-puff/styles.ts
+++ b/packages/ts-components/src/components/newsletter-puff/styles.ts
@@ -43,16 +43,16 @@ export const InpContainer = styled(View)<{ section?: string }>`
   margin-right: ${spacing(2)};
   margin-bottom: ${spacing(4)};
   margin-left: ${spacing(2)};
-  height: 157.5px;
+  height: 157.5;
 
   @media (min-width: ${breakpoints.medium}px) {
     margin: 0 auto ${spacing(4)};
     width: 80.8%;
-    height: 157.5px;
+    height: 157.5;
   }
   @media (min-width: ${breakpoints.wide}px) {
     width: 56.2%;
-    height: 117.5px;
+    height: 117.5;
   }
 `;
 

--- a/packages/ts-components/src/components/newsletter-puff/styles.ts
+++ b/packages/ts-components/src/components/newsletter-puff/styles.ts
@@ -43,13 +43,16 @@ export const InpContainer = styled(View)<{ section?: string }>`
   margin-right: ${spacing(2)};
   margin-bottom: ${spacing(4)};
   margin-left: ${spacing(2)};
+  height: 157.5px;
 
   @media (min-width: ${breakpoints.medium}px) {
     margin: 0 auto ${spacing(4)};
     width: 80.8%;
+    height: 157.5px;
   }
   @media (min-width: ${breakpoints.wide}px) {
     width: 56.2%;
+    height: 117.5px;
   }
 `;
 

--- a/packages/ts-components/src/components/newsletter-puff/styles.ts
+++ b/packages/ts-components/src/components/newsletter-puff/styles.ts
@@ -43,16 +43,16 @@ export const InpContainer = styled(View)<{ section?: string }>`
   margin-right: ${spacing(2)};
   margin-bottom: ${spacing(4)};
   margin-left: ${spacing(2)};
-  height: 157.5;
+  height: 157.5px;
 
   @media (min-width: ${breakpoints.medium}px) {
     margin: 0 auto ${spacing(4)};
     width: 80.8%;
-    height: 157.5;
+    height: 157.5px;
   }
   @media (min-width: ${breakpoints.wide}px) {
     width: 56.2%;
-    height: 117.5;
+    height: 117.5px;
   }
 `;
 


### PR DESCRIPTION
### Description

We have been investigating CLS on the website and the automated newsletter puff has been flagged. See video below - the loading state doesn’t match the component and is causing layout shift. 

Would be good to get a lighthouse test on it (WebPageTest won’t work as won’t meet the user criteria for rendering it) before and after to note whether it has improved the CLS score. 

Check the manually placed Newsletter as well as I believe it’s the same component but could have different loading states, this video is the automated one. Example article: Signs of insider dealing detected in a third of UK takeover bids 

[JIRA-1221](https://nidigitalsolutions.jira.com/browse/TMD-1221)

### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?
