### PR TITLE
feat(TMD-1185): POC for change sort order of the comment

### DIFF
--- a/packages/article-comments/src/comments.js
+++ b/packages/article-comments/src/comments.js
@@ -141,6 +141,10 @@ class Comments extends Component {
     );
     launcherScript.setAttribute("data-seo-enabled", true);
     launcherScript.setAttribute("data-livefyre-url", articleId);
+    //This is only for testing purposes, ideally this should be coming from the TPA like best , newest or oldest
+    if (articleId === "91616c4d-ae74-431c-842e-50d357da91e7") {
+      launcherScript.setAttribute("data-sort-by", "newest");
+    }
 
     this.container.appendChild(launcherScript);
   }


### PR DESCRIPTION
### Description

Can we set the default order of the comments within the article below to be sorted by newest (as opposed to recommended) by default?

[The 19 best books of 2024 — chosen by our critics](https://www.thetimes.com/culture/books/article/the-best-books-of-2024-5spv735xb) 

OpenWeb documentation:

[Conversation](https://developers.openweb.com/docs/conversation#:~:text=false-,data%2Dsort%2Dby,-string) 

From the openweb docs it seems we can control the sort order by setting a value on the container element. Current options are

best 

newest 

oldest

Acceptance Criteria


Comments within the Comments section of this article are sorted by default by Newest
[JIRA-1185](https://nidigitalsolutions.jira.com/browse/TMD-1185)


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?

