### PR TITLE
feat(tmc-319): Button not visible if text is empty

### DIFF
--- a/packages/ts-components/src/components/cta-button/CtaButton.tsx
+++ b/packages/ts-components/src/components/cta-button/CtaButton.tsx
@@ -15,7 +15,7 @@ interface RootProps {
 export const CtaButton: React.FC<RootProps> = props => {
   const attributes = props.attributes;
 
-  if (!attributes || !attributes.text.trim()) {
+  if (!attributes || !attributes.text.trim() || !attributes.url.trim()) {
     return null;
   }
 

--- a/packages/ts-components/src/components/cta-button/CtaButton.tsx
+++ b/packages/ts-components/src/components/cta-button/CtaButton.tsx
@@ -15,7 +15,11 @@ interface RootProps {
 export const CtaButton: React.FC<RootProps> = props => {
   const attributes = props.attributes;
 
-  return attributes ? (
+  if (!attributes || !attributes.text.trim()) {
+    return null;
+  }
+
+  return (
     <Link
       href={attributes.url}
       target={attributes.target || '_blank'}
@@ -30,5 +34,5 @@ export const CtaButton: React.FC<RootProps> = props => {
     >
       {attributes.text}
     </Link>
-  ) : null;
+  );
 };

--- a/packages/ts-components/src/components/cta-button/__tests__/CtaButton.test.tsx
+++ b/packages/ts-components/src/components/cta-button/__tests__/CtaButton.test.tsx
@@ -43,4 +43,11 @@ describe('CtaButton Component', () => {
     );
     expect(whitespaceTextContainer.firstChild).toBeNull();
   });
+
+  it('does not render anything if url is missing or empty', () => {
+    const { container: noUrlContainer } = render(
+      <CtaButton attributes={{ ...defaultProps, url: '' }} />
+    );
+    expect(noUrlContainer.firstChild).toBeNull();
+  });
 });

--- a/packages/ts-components/src/components/cta-button/__tests__/CtaButton.test.tsx
+++ b/packages/ts-components/src/components/cta-button/__tests__/CtaButton.test.tsx
@@ -31,4 +31,16 @@ describe('CtaButton Component', () => {
     const { container } = render(<CtaButton />);
     expect(container.firstChild).toBeNull();
   });
+
+  it('does not render anything if text is empty or contains only whitespace', () => {
+    const { container: emptyTextContainer } = render(
+      <CtaButton attributes={{ ...defaultProps, text: '' }} />
+    );
+    expect(emptyTextContainer.firstChild).toBeNull();
+
+    const { container: whitespaceTextContainer } = render(
+      <CtaButton attributes={{ ...defaultProps, text: '   ' }} />
+    );
+    expect(whitespaceTextContainer.firstChild).toBeNull();
+  });
 });


### PR DESCRIPTION
### Description

The CTA button should not appear if there are no text or url entered.

[TMC-319](https://nidigitalsolutions.jira.com/browse/TMC-319)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.


[TMC-319]: https://nidigitalsolutions.jira.com/browse/TMC-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ