### PR TITLE
feat(TMD-1364): Key moments block cutting off content when placed low…

### DIFF
--- a/packages/key-facts/src/key-facts.js
+++ b/packages/key-facts/src/key-facts.js
@@ -27,8 +27,14 @@ const KeyFacts = ({ ast, section, headline, isLiveOrBreaking }) => {
     attributes: { title }
   } = ast;
 
+
+
   const { children: keyFactsItems } = children[0];
   const formattedKeyFactItems = formatPaywallItems(keyFactsItems);
+
+  console.log("ast, section, headline, isLiveOrBreaking",ast, section, headline, isLiveOrBreaking)
+  console.log("keyFactsItems", keyFactsItems)
+  console.log("formattedKeyFactItems",formattedKeyFactItems)
 
   const articleFlag = isLiveOrBreaking
     ? isLiveOrBreaking.toLowerCase()

--- a/packages/key-facts/src/key-facts.js
+++ b/packages/key-facts/src/key-facts.js
@@ -8,17 +8,19 @@ import { KeyFactsTitle, KeyFactsContainer } from "./styles";
 
 // Function to convert key items incorrectly marked as "paywall" into list items
 function formatPaywallItems(items) {
-  return [...items].map(
-    item =>
-      item.name === "paywall"
-        ? { ...item.children[0] }
-        : {
-            ...item,
-            children: item.children.map(
-              i => (i.name === "paywall" ? { ...i.children[0] } : i)
-            )
-          }
-  );
+  const flattenedItems = items.reduce((accumulator, currentValue) => {
+    if (currentValue.name === "paywall") {
+      return accumulator.concat(currentValue.children);
+    }
+    return accumulator.concat([currentValue]);
+  }, []);
+
+  return [...flattenedItems].map(item => ({
+    ...item,
+    children: item.children.map(
+      i => (i.name === "paywall" ? { ...i.children[0] } : i)
+    )
+  }));
 }
 
 const KeyFacts = ({ ast, section, headline, isLiveOrBreaking }) => {
@@ -27,14 +29,8 @@ const KeyFacts = ({ ast, section, headline, isLiveOrBreaking }) => {
     attributes: { title }
   } = ast;
 
-
-
   const { children: keyFactsItems } = children[0];
   const formattedKeyFactItems = formatPaywallItems(keyFactsItems);
-
-  console.log("ast, section, headline, isLiveOrBreaking",ast, section, headline, isLiveOrBreaking)
-  console.log("keyFactsItems", keyFactsItems)
-  console.log("formattedKeyFactItems",formattedKeyFactItems)
 
   const articleFlag = isLiveOrBreaking
     ? isLiveOrBreaking.toLowerCase()


### PR DESCRIPTION
### Description

The issue was that we expected only one item under the paywall key items array.
With this PR, we will move all paywall key items to the top array to format it correctly.

[TMD-1364](https://nidigitalsolutions.jira.com/browse/TMD-1364)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Before:
<img width="721" alt="image" src="https://github.com/user-attachments/assets/e56758ac-486b-4b3d-a1ea-953020c3f085" />


After:

<img width="696" alt="image" src="https://github.com/user-attachments/assets/7758f275-4ef2-4698-9cb2-0c54f5c97070" />


[TMD-1364]: https://nidigitalsolutions.jira.com/browse/TMD-1364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ