### PR TITLE
feature(TMC-339): Added logic which reorders interactive and ad elements in article

### DIFF
--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -49,6 +49,7 @@ import insertDropcapIntoAST from "./contentModifiers/dropcap-util";
 import insertNewsletterPuff from "./contentModifiers/newsletter-puff";
 import insertInlineAd from "./contentModifiers/inline-ad";
 import mapListElements from "./contentModifiers/map-list-elements";
+import reorderInteractiveBeforeAd from "./contentModifiers/reorder-interactive-before-ad";
 import { getIsLiveOrBreakingFlag } from "./data-helper";
 
 export const reduceArticleContent = (content, reducers) =>
@@ -181,7 +182,8 @@ const ArticleSkeleton = ({
     insertNewsletterPuff(section, isPreview, expirableFlags),
     insertInlineAd(isPreview),
     tagLastParagraph,
-    mapListElements
+    mapListElements,
+    reorderInteractiveBeforeAd
   ];
 
   const newContent = reduceArticleContent(content, articleContentReducers);

--- a/packages/article-skeleton/src/contentModifiers/reorder-interactive-before-ad.js
+++ b/packages/article-skeleton/src/contentModifiers/reorder-interactive-before-ad.js
@@ -1,0 +1,28 @@
+const reorderInteractiveBeforeAd = content => {
+  const paywallElement = content.find(item => item.name === "paywall");
+
+  if (!paywallElement || !Array.isArray(paywallElement.children)) {
+    return content;
+  }
+
+  const paywallChildren = paywallElement.children;
+  /* eslint-disable no-plusplus */
+  for (let i = 0; i < paywallChildren.length - 2; i++) {
+    if (
+      paywallChildren[i].name === "paragraph" &&
+      paywallChildren[i + 1].name.includes("inlineAd") &&
+      paywallChildren[i + 2].name === "interactive" &&
+      paywallChildren[i + 2].attributes.element.value === "times-travel-cta"
+    ) {
+      [paywallChildren[i + 1], paywallChildren[i + 2]] = [
+        paywallChildren[i + 2],
+        paywallChildren[i + 1]
+      ];
+    }
+  }
+
+  // Return the modified content
+  return content;
+};
+
+export default reorderInteractiveBeforeAd;

--- a/packages/article-skeleton/src/contentModifiers/reorder-interactive-before-ad.js
+++ b/packages/article-skeleton/src/contentModifiers/reorder-interactive-before-ad.js
@@ -6,11 +6,13 @@ const reorderInteractiveBeforeAd = content => {
   }
 
   const paywallChildren = paywallElement.children;
-  /* eslint-disable no-plusplus */
+ 
   for (let i = 0; i < paywallChildren.length - 2; i++) {
     if (
-      paywallChildren[i].name === "paragraph" &&
-      paywallChildren[i + 1].name.includes("inlineAd") &&
+      paywallChildren[i].name === "paragraph" && (
+        paywallChildren[i + 1].name.includes("inlineAd") || paywallChildren[i + 1].name === "ad"
+      )
+       &&
       paywallChildren[i + 2].name === "interactive" &&
       paywallChildren[i + 2].attributes.element.value === "times-travel-cta"
     ) {
@@ -21,7 +23,7 @@ const reorderInteractiveBeforeAd = content => {
     }
   }
 
-  // Return the modified content
+  
   return content;
 };
 

--- a/packages/article-skeleton/src/contentModifiers/reorder-interactive-before-ad.js
+++ b/packages/article-skeleton/src/contentModifiers/reorder-interactive-before-ad.js
@@ -6,13 +6,13 @@ const reorderInteractiveBeforeAd = content => {
   }
 
   const paywallChildren = paywallElement.children;
- 
+
+  // eslint-disable-next-line no-plusplus
   for (let i = 0; i < paywallChildren.length - 2; i++) {
     if (
-      paywallChildren[i].name === "paragraph" && (
-        paywallChildren[i + 1].name.includes("inlineAd") || paywallChildren[i + 1].name === "ad"
-      )
-       &&
+      paywallChildren[i].name === "paragraph" &&
+      (paywallChildren[i + 1].name.includes("inlineAd") ||
+        paywallChildren[i + 1].name === "ad") &&
       paywallChildren[i + 2].name === "interactive" &&
       paywallChildren[i + 2].attributes.element.value === "times-travel-cta"
     ) {
@@ -23,7 +23,6 @@ const reorderInteractiveBeforeAd = content => {
     }
   }
 
-  
   return content;
 };
 


### PR DESCRIPTION
### Description

Added logic that tracks elements in article and on every occurrence of ad dividing cta button from paragraph, we reorder and put cta button above advertisment.

[TMC-339](https://nidigitalsolutions.jira.com/browse/TMC-339)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

BEFORE:
<img width="1182" alt="Screenshot 2025-02-11 at 15 53 47" src="https://github.com/user-attachments/assets/442afe1a-752b-4d5c-b0c6-7a9d65003cbe" />

AFTER:
<img width="1192" alt="Screenshot 2025-02-11 at 15 52 52" src="https://github.com/user-attachments/assets/91e9a8da-d829-4230-b85e-a6938de54306" />



[TMC-339]: https://nidigitalsolutions.jira.com/browse/TMC-339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ