### PR TITLE
feat(tmc-362): change ad label from h2 to span

### DIFF
--- a/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -212,6 +212,7 @@ exports[`full article with style 1`] = `
   padding: 0 0 5px;
   text-align: center;
   text-transform: uppercase;
+  display: block;
 }
 
 .c11 {
@@ -1021,11 +1022,11 @@ exports[`full article with style 1`] = `
             <div
               className="c27"
             >
-              <h2
+              <span
                 className="c28"
               >
                 Advertisement
-              </h2>
+              </span>
               <AdContainer />
             </div>
             <div>
@@ -1271,6 +1272,7 @@ exports[`full article with style in the culture magazine 1`] = `
   padding: 0 0 5px;
   text-align: center;
   text-transform: uppercase;
+  display: block;
 }
 
 .c11 {
@@ -2081,11 +2083,11 @@ exports[`full article with style in the culture magazine 1`] = `
             <div
               className="c27"
             >
-              <h2
+              <span
                 className="c28"
               >
                 Advertisement
-              </h2>
+              </span>
               <AdContainer />
             </div>
             <div>
@@ -2331,6 +2333,7 @@ exports[`full article with style in the style magazine 1`] = `
   padding: 0 0 5px;
   text-align: center;
   text-transform: uppercase;
+  display: block;
 }
 
 .c11 {
@@ -3142,11 +3145,11 @@ exports[`full article with style in the style magazine 1`] = `
             <div
               className="c27"
             >
-              <h2
+              <span
                 className="c28"
               >
                 Advertisement
-              </h2>
+              </span>
               <AdContainer />
             </div>
             <div>
@@ -3392,6 +3395,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
   padding: 0 0 5px;
   text-align: center;
   text-transform: uppercase;
+  display: block;
 }
 
 .c11 {
@@ -4202,11 +4206,11 @@ exports[`full article with style in the sunday times magazine 1`] = `
             <div
               className="c27"
             >
-              <h2
+              <span
                 className="c28"
               >
                 Advertisement
-              </h2>
+              </span>
               <AdContainer />
             </div>
             <div>

--- a/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -483,9 +483,9 @@ exports[`4. an article with ads with .co.uk 1`] = `
         <div>
           <div>
             <div>
-              <h2>
+              <span>
                 Advertisement
-              </h2>
+              </span>
               <AdContainer
                 slotName="inline-ad"
               />
@@ -771,9 +771,9 @@ exports[`5. an article with ads with .com 1`] = `
         <div>
           <div>
             <div>
-              <h2>
+              <span>
                 Advertisement
-              </h2>
+              </span>
               <AdContainer
                 slotName="inline-ad"
               />

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -212,6 +212,7 @@ exports[`full article with style 1`] = `
   padding: 0 0 5px;
   text-align: center;
   text-transform: uppercase;
+  display: block;
 }
 
 .c2 {
@@ -1041,11 +1042,11 @@ exports[`full article with style 1`] = `
             <div
               className="c26"
             >
-              <h2
+              <span
                 className="c27"
               >
                 Advertisement
-              </h2>
+              </span>
               <AdContainer />
             </div>
             <div>
@@ -1291,6 +1292,7 @@ exports[`full article with style in the culture magazine 1`] = `
   padding: 0 0 5px;
   text-align: center;
   text-transform: uppercase;
+  display: block;
 }
 
 .c2 {
@@ -2121,11 +2123,11 @@ exports[`full article with style in the culture magazine 1`] = `
             <div
               className="c26"
             >
-              <h2
+              <span
                 className="c27"
               >
                 Advertisement
-              </h2>
+              </span>
               <AdContainer />
             </div>
             <div>
@@ -2371,6 +2373,7 @@ exports[`full article with style in the style magazine 1`] = `
   padding: 0 0 5px;
   text-align: center;
   text-transform: uppercase;
+  display: block;
 }
 
 .c2 {
@@ -3202,11 +3205,11 @@ exports[`full article with style in the style magazine 1`] = `
             <div
               className="c26"
             >
-              <h2
+              <span
                 className="c27"
               >
                 Advertisement
-              </h2>
+              </span>
               <AdContainer />
             </div>
             <div>
@@ -3452,6 +3455,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
   padding: 0 0 5px;
   text-align: center;
   text-transform: uppercase;
+  display: block;
 }
 
 .c2 {
@@ -4282,11 +4286,11 @@ exports[`full article with style in the sunday times magazine 1`] = `
             <div
               className="c26"
             >
-              <h2
+              <span
                 className="c27"
               >
                 Advertisement
-              </h2>
+              </span>
               <AdContainer />
             </div>
             <div>

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -463,9 +463,9 @@ exports[`4. an article with ads with .co.uk 1`] = `
         <div>
           <div>
             <div>
-              <h2>
+              <span>
                 Advertisement
-              </h2>
+              </span>
               <AdContainer
                 slotName="inline-ad"
               />
@@ -741,9 +741,9 @@ exports[`5. an article with ads with .com 1`] = `
         <div>
           <div>
             <div>
-              <h2>
+              <span>
                 Advertisement
-              </h2>
+              </span>
               <AdContainer
                 slotName="inline-ad"
               />

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -212,6 +212,7 @@ exports[`full article with style 1`] = `
   padding: 0 0 5px;
   text-align: center;
   text-transform: uppercase;
+  display: block;
 }
 
 .c2 {
@@ -961,11 +962,11 @@ exports[`full article with style 1`] = `
             <div
               className="c25"
             >
-              <h2
+              <span
                 className="c26"
               >
                 Advertisement
-              </h2>
+              </span>
               <AdContainer />
             </div>
             <div>
@@ -1211,6 +1212,7 @@ exports[`full article with style in the culture magazine 1`] = `
   padding: 0 0 5px;
   text-align: center;
   text-transform: uppercase;
+  display: block;
 }
 
 .c2 {
@@ -1961,11 +1963,11 @@ exports[`full article with style in the culture magazine 1`] = `
             <div
               className="c25"
             >
-              <h2
+              <span
                 className="c26"
               >
                 Advertisement
-              </h2>
+              </span>
               <AdContainer />
             </div>
             <div>
@@ -2211,6 +2213,7 @@ exports[`full article with style in the style magazine 1`] = `
   padding: 0 0 5px;
   text-align: center;
   text-transform: uppercase;
+  display: block;
 }
 
 .c2 {
@@ -2962,11 +2965,11 @@ exports[`full article with style in the style magazine 1`] = `
             <div
               className="c25"
             >
-              <h2
+              <span
                 className="c26"
               >
                 Advertisement
-              </h2>
+              </span>
               <AdContainer />
             </div>
             <div>
@@ -3212,6 +3215,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
   padding: 0 0 5px;
   text-align: center;
   text-transform: uppercase;
+  display: block;
 }
 
 .c2 {
@@ -3962,11 +3966,11 @@ exports[`full article with style in the sunday times magazine 1`] = `
             <div
               className="c25"
             >
-              <h2
+              <span
                 className="c26"
               >
                 Advertisement
-              </h2>
+              </span>
               <AdContainer />
             </div>
             <div>

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -489,9 +489,9 @@ exports[`4. an article with ads with .co.uk 1`] = `
         <div>
           <div>
             <div>
-              <h2>
+              <span>
                 Advertisement
-              </h2>
+              </span>
               <AdContainer
                 slotName="inline-ad"
               />
@@ -780,9 +780,9 @@ exports[`5. an article with ads with .com 1`] = `
         <div>
           <div>
             <div>
-              <h2>
+              <span>
                 Advertisement
-              </h2>
+              </span>
               <AdContainer
                 slotName="inline-ad"
               />

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -212,6 +212,7 @@ exports[`full article with style 1`] = `
   padding: 0 0 5px;
   text-align: center;
   text-transform: uppercase;
+  display: block;
 }
 
 .c2 {
@@ -981,11 +982,11 @@ exports[`full article with style 1`] = `
             <div
               className="c25"
             >
-              <h2
+              <span
                 className="c26"
               >
                 Advertisement
-              </h2>
+              </span>
               <AdContainer />
             </div>
             <div>

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -433,9 +433,9 @@ exports[`4. an article with ads with .co.uk 1`] = `
         <div>
           <div>
             <div>
-              <h2>
+              <span>
                 Advertisement
-              </h2>
+              </span>
               <AdContainer
                 slotName="inline-ad"
               />
@@ -696,9 +696,9 @@ exports[`5. an article with ads with .com 1`] = `
         <div>
           <div>
             <div>
-              <h2>
+              <span>
                 Advertisement
-              </h2>
+              </span>
               <AdContainer
                 slotName="inline-ad"
               />

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -212,6 +212,7 @@ exports[`full article with style 1`] = `
   padding: 0 0 5px;
   text-align: center;
   text-transform: uppercase;
+  display: block;
 }
 
 .c12 {
@@ -956,11 +957,11 @@ exports[`full article with style 1`] = `
               <div
                 className="c25"
               >
-                <h2
+                <span
                   className="c26"
                 >
                   Advertisement
-                </h2>
+                </span>
                 <AdContainer />
               </div>
               <div>

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -626,9 +626,9 @@ exports[`5. an article with ads 1`] = `
           <div>
             <div>
               <div>
-                <h2>
+                <span>
                   Advertisement
-                </h2>
+                </span>
                 <AdContainer
                   slotName="inline-ad"
                 />

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -190,9 +190,9 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
               Some content
             </p>
             <div>
-              <h2>
+              <span>
                 Advertisement
-              </h2>
+              </span>
               <AdContainer
                 slotName="inline-ad"
               />

--- a/packages/article-skeleton/src/styles/article-body/responsive.js
+++ b/packages/article-skeleton/src/styles/article-body/responsive.js
@@ -245,7 +245,7 @@ export const InlineAdWrapper = styled.div`
   }
 `;
 
-export const InlineAdTitle = styled.h2`
+export const InlineAdTitle = styled.span`
   border-bottom: 1px solid rgb(219, 219, 219);
   color: #696969;
   flex: 1 1 100%;

--- a/packages/article-skeleton/src/styles/article-body/responsive.js
+++ b/packages/article-skeleton/src/styles/article-body/responsive.js
@@ -255,4 +255,5 @@ export const InlineAdTitle = styled.span`
   padding: 0 0 5px;
   text-align: center;
   text-transform: uppercase;
+  display: block;
 `;


### PR DESCRIPTION
### Description

Advertisement label - H2 tag is changed to <span> on Article template.

[TMC-362](https://nidigitalsolutions.jira.com/browse/TMC-362)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.


[TMC-362]: https://nidigitalsolutions.jira.com/browse/TMC-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ