### PR TITLE
fix(TMRP-193): indents on unordered lists

### DIFF
--- a/packages/article-skeleton/src/contentModifiers/map-list-elements.js
+++ b/packages/article-skeleton/src/contentModifiers/map-list-elements.js
@@ -1,6 +1,13 @@
-export default children => {
+// This function maps over the content to remove list elements from
+// being rendered inside paragraphs as this is invalid HTML.
+// It returns an array with the list elements not being a child of a paragraph.
+
+function mapListElements(children) {
   const newContent = children.map(child => {
-    if (child.name === "paragraph") {
+    if (child.name === "paragraph" || child.name === "paywall") {
+      if (child.name === "paywall") {
+        mapListElements(child.children);
+      }
       if (
         child.children.length === 1 &&
         child.children[0].name === "unorderedList"
@@ -13,4 +20,6 @@ export default children => {
     return child;
   });
   return newContent;
-};
+}
+
+export default mapListElements;


### PR DESCRIPTION
### Description

Fixes indentation issue with unordered lists rendering within paywalled content as they were not mapped correctly.

[TMRP-193](https://nidigitalsolutions.jira.com/browse/TMRP-193)


### Checklist

- [X] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots:

**BEFORE**
<img width="680" alt="Screenshot 2025-02-25 at 12 36 40" src="https://github.com/user-attachments/assets/6fc28e00-c36c-46d4-a4b9-36c15a4c89c9" />

**AFTER**
<img width="697" alt="Screenshot 2025-02-25 at 12 36 24" src="https://github.com/user-attachments/assets/8dee04ca-3a2f-44d4-8203-d185ee00f573" />



[TMRP-193]: https://nidigitalsolutions.jira.com/browse/TMRP-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ