### PR TITLE
feat(TMG-3003): Add blue dot to share button

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       - run:
           name: Run Web Tests
           command: |
-            lerna run test:web --stream --since -- -- --ci --bail --coverage
+            lerna run test:web --since -- -- --ci --coverage --verbose --runInBand --logHeapUsage
           working_directory: ~/project/
 
   run_unit_tests:

--- a/packages/article-extras/src/article-extras.js
+++ b/packages/article-extras/src/article-extras.js
@@ -123,24 +123,22 @@ const ArticleExtras = ({
       {renderBreadcrumb({ showBorder: topics && topics.length > 0 })}
       <ArticleTopics topics={topics} />
       {isSharingSavingEnabled && (
-        <UserState state={UserState.showSaveAndShareBar}>
-          <MessageContext.Consumer>
-            {({ showMessage }) => (
-              <ShareAndSaveContainer showBottomBorder={!relatedArticleSlice}>
-                <SaveAndShareBar
-                  articleId={articleId}
-                  articleHeadline={articleHeadline}
-                  articleUrl={articleUrl}
-                  onCopyLink={() => showMessage("Article link copied")}
-                  onSaveToMyArticles={() => {}}
-                  onShareOnEmail={() => {}}
-                  savingEnabled={savingEnabled}
-                  sharingEnabled={sharingEnabled}
-                />
-              </ShareAndSaveContainer>
-            )}
-          </MessageContext.Consumer>
-        </UserState>
+        <MessageContext.Consumer>
+          {({ showMessage }) => (
+            <ShareAndSaveContainer showBottomBorder={!relatedArticleSlice}>
+              <SaveAndShareBar
+                articleId={articleId}
+                articleHeadline={articleHeadline}
+                articleUrl={articleUrl}
+                onCopyLink={() => showMessage("Article link copied")}
+                onSaveToMyArticles={() => {}}
+                onShareOnEmail={() => {}}
+                savingEnabled={savingEnabled}
+                sharingEnabled={sharingEnabled}
+              />
+            </ShareAndSaveContainer>
+          )}
+        </MessageContext.Consumer>
       )}
       {sponsoredArticlesAndRelatedArticles(true, false)}
       <ArticleComments

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -332,23 +332,21 @@ const ArticleSkeleton = ({
                 )}
                 <Header />
                 {isSharingSavingEnabled ? (
-                  <UserState state={UserState.showSaveAndShareBar}>
-                    <MessageContext.Consumer>
-                      {({ showMessage }) => (
-                        <StickySaveAndShareBar
-                          articleId={articleId}
-                          articleHeadline={headline}
-                          articleUrl={articleUrl}
-                          onCopyLink={() => showMessage("Article link copied")}
-                          onSaveToMyArticles={() => {}}
-                          onShareOnEmail={() => {}}
-                          savingEnabled={savingEnabled}
-                          sharingEnabled={sharingEnabled}
-                          hostName={domainSpecificUrl}
-                        />
-                      )}
-                    </MessageContext.Consumer>
-                  </UserState>
+                  <MessageContext.Consumer>
+                    {({ showMessage }) => (
+                      <StickySaveAndShareBar
+                        articleId={articleId}
+                        articleHeadline={headline}
+                        articleUrl={articleUrl}
+                        onCopyLink={() => showMessage("Article link copied")}
+                        onSaveToMyArticles={() => {}}
+                        onShareOnEmail={() => {}}
+                        savingEnabled={savingEnabled}
+                        sharingEnabled={sharingEnabled}
+                        hostName={domainSpecificUrl}
+                      />
+                    )}
+                  </MessageContext.Consumer>
                 ) : null}
                 {!!zephrDivs && (
                   <StaticContent

--- a/packages/save-and-share-bar/__tests__/shared.base.js
+++ b/packages/save-and-share-bar/__tests__/shared.base.js
@@ -15,6 +15,8 @@ const mockEvent = {
 };
 
 jest.mock("@times-components/utils", () => ({
+  __esModule: true,
+  ...jest.requireActual("@times-components/utils"),
   checkForSymphonyExperiment: jest.fn()
 }));
 

--- a/packages/save-and-share-bar/__tests__/shared.base.js
+++ b/packages/save-and-share-bar/__tests__/shared.base.js
@@ -1,7 +1,7 @@
 /* eslint-env browser */
 import React from "react";
 import TestRenderer, { act } from "react-test-renderer";
-import { checkForSymphonyExperiment } from "@times-components/utils/src/check-for-symphony-experiment";
+import { checkForSymphonyExperiment } from "@times-components/utils";
 import { UserState } from "./mocks";
 import mockGetTokenisedArticleUrl from "./mock-get-tokenised-article-url";
 import { ShareItem } from "../src/components/share-item";
@@ -14,7 +14,7 @@ const mockEvent = {
   preventDefault: () => {}
 };
 
-jest.mock("@times-components/utils/src/check-for-symphony-experiment", () => ({
+jest.mock("@times-components/utils", () => ({
   checkForSymphonyExperiment: jest.fn()
 }));
 

--- a/packages/save-and-share-bar/__tests__/shared.base.js
+++ b/packages/save-and-share-bar/__tests__/shared.base.js
@@ -81,7 +81,7 @@ export default () => {
       );
       expect(testInstance.toJSON()).toMatchSnapshot();
     });
-    it("renders the Share button highlight when Project Symphony is on and Share button has not been clicked", () => {
+    it("renders the Share button highlight when Project Symphony is on, Share button has not been clicked on this page and Share button highlight has not been previously seen on other articles", () => {
       UserState.mockStates = [UserState.showSaveAndShareBar];
       checkForSymphonyExperiment.mockReturnValue(true);
       const testInstance = TestRenderer.create(

--- a/packages/save-and-share-bar/__tests__/shared.base.js
+++ b/packages/save-and-share-bar/__tests__/shared.base.js
@@ -1,17 +1,22 @@
 /* eslint-env browser */
 import React from "react";
 import TestRenderer, { act } from "react-test-renderer";
+import { checkForSymphonyExperiment } from "@times-components/utils/src/check-for-symphony-experiment";
 import { UserState } from "./mocks";
 import mockGetTokenisedArticleUrl from "./mock-get-tokenised-article-url";
 import { ShareItem } from "../src/components/share-item";
 import SaveAndShareBar from "../src/save-and-share-bar";
 import EmailShare from "../src/components/email-share";
-import { OutlineButton } from "../src/styled";
+import { OutlineButton, ShareButtonHighlightContainer } from "../src/styled";
 import MockedProvider from "../../provider-test-tools/src/mocked-provider";
 
 const mockEvent = {
   preventDefault: () => {}
 };
+
+jest.mock("@times-components/utils/src/check-for-symphony-experiment", () => ({
+  checkForSymphonyExperiment: jest.fn()
+}));
 
 export default () => {
   describe("save and share bar component", () => {
@@ -73,6 +78,49 @@ export default () => {
         </MockedProvider>
       );
       expect(testInstance.toJSON()).toMatchSnapshot();
+    });
+    it("renders the Share button highlight when Project Symphony is on and Share button has not been clicked", () => {
+      UserState.mockStates = [UserState.showSaveAndShareBar];
+      checkForSymphonyExperiment.mockReturnValue(true);
+      const testInstance = TestRenderer.create(
+        <MockedProvider>
+          <SaveAndShareBar {...props} />
+        </MockedProvider>
+      );
+      expect(
+        testInstance.root.findAllByType(ShareButtonHighlightContainer)
+      ).toBeDefined();
+    });
+    it("does not render the Share button highlight when Project Symphony is on and Share button has been clicked", () => {
+      UserState.mockStates = [UserState.showSaveAndShareBar];
+      checkForSymphonyExperiment.mockReturnValue(true);
+      const testInstance = TestRenderer.create(
+        <MockedProvider>
+          <SaveAndShareBar {...props} />
+        </MockedProvider>
+      );
+      act(() => {
+        testInstance.root
+          .findAllByType(OutlineButton)[0]
+          .props.onClick(mockEvent);
+      });
+      const shareButtonHighlightContainers = testInstance.root.findAllByType(
+        ShareButtonHighlightContainer
+      );
+      expect(shareButtonHighlightContainers.length).toBe(0);
+    });
+    it("does not render the Share button highlight when Project Symphony is not on", () => {
+      UserState.mockStates = [UserState.showSaveAndShareBar];
+      checkForSymphonyExperiment.mockReturnValue(false);
+      const testInstance = TestRenderer.create(
+        <MockedProvider>
+          <SaveAndShareBar {...props} />
+        </MockedProvider>
+      );
+      const shareButtonHighlightContainers = testInstance.root.findAllByType(
+        ShareButtonHighlightContainer
+      );
+      expect(shareButtonHighlightContainers.length).toBe(0);
     });
     it("onPress events triggers correctly", () => {
       const testInstance = TestRenderer.create(

--- a/packages/save-and-share-bar/__tests__/shared.base.js
+++ b/packages/save-and-share-bar/__tests__/shared.base.js
@@ -93,6 +93,23 @@ export default () => {
         testInstance.root.findAllByType(ShareButtonHighlightContainer)
       ).toBeDefined();
     });
+    it("does not render the Share button highlight when Project Symphony is on, Share button has not been clicked on this page and the Share button highlight has been dismissed on previously viewed articles", () => {
+      UserState.mockStates = [UserState.showSaveAndShareBar];
+      checkForSymphonyExperiment.mockReturnValue(true);
+      window.localStorage.setItem(
+        "hasShareButtonHighlightBeenDismissed",
+        "true"
+      );
+      const testInstance = TestRenderer.create(
+        <MockedProvider>
+          <SaveAndShareBar {...props} />
+        </MockedProvider>
+      );
+      const shareButtonHighlightContainers = testInstance.root.findAllByType(
+        ShareButtonHighlightContainer
+      );
+      expect(shareButtonHighlightContainers.length).toBe(0);
+    });
     it("does not render the Share button highlight when Project Symphony is on and Share button has been clicked", () => {
       UserState.mockStates = [UserState.showSaveAndShareBar];
       checkForSymphonyExperiment.mockReturnValue(true);

--- a/packages/save-and-share-bar/__tests__/web/__snapshots__/save-and-share-bar.test.js.snap
+++ b/packages/save-and-share-bar/__tests__/web/__snapshots__/save-and-share-bar.test.js.snap
@@ -15,7 +15,7 @@ exports[`save and share bar component email icon when tokenising with loading st
       className="share-item__IconContainer-sc-1idd4zx-3 dwBDja"
     >
       <div
-        className="styled__EmailSpinnerContainer-qkwc0r-8 jwSyWD"
+        className="styled__EmailSpinnerContainer-qkwc0r-10 cRrJdh"
       >
         <IconActivityIndicator
           size="small"
@@ -37,10 +37,10 @@ exports[`save and share bar component save and share bar renders correctly when 
   data-testid="save-and-share-bar"
 >
   <div
-    className="styled__ShareButtonContainer-qkwc0r-1 vORLH"
+    className="styled__ShareButtonContainer-qkwc0r-1 cxdDMy"
   >
     <button
-      className="styled__OutlineButton-qkwc0r-2 ljZNyf"
+      className="styled__OutlineButton-qkwc0r-4 jWKrMk"
     >
       <svg
         aria-hidden="true"
@@ -59,16 +59,16 @@ exports[`save and share bar component save and share bar renders correctly when 
     </button>
     <div
       aria-expanded={false}
-      className="styled__Popover-qkwc0r-3 jfAJcD"
+      className="styled__Popover-qkwc0r-5 kDlDSt"
     >
       <div
-        className="styled__PopoverHeader-qkwc0r-4 dwnPtB"
+        className="styled__PopoverHeader-qkwc0r-6 etSOho"
       >
         <h3>
           Share this article
         </h3>
         <button
-          className="styled__CloseButton-qkwc0r-6 drykZc"
+          className="styled__CloseButton-qkwc0r-8 dbcqZq"
         >
           <svg
             fill="none"
@@ -85,7 +85,7 @@ exports[`save and share bar component save and share bar renders correctly when 
         </button>
       </div>
       <div
-        className="styled__PopoverContent-qkwc0r-5 dKaMVi"
+        className="styled__PopoverContent-qkwc0r-7 etEKKi"
       >
         <a
           className="share-item__StyledLink-sc-1idd4zx-2 iTJLEp"
@@ -214,10 +214,10 @@ exports[`save and share bar component save and share bar renders correctly when 
   data-testid="save-and-share-bar"
 >
   <div
-    className="styled__ShareButtonContainer-qkwc0r-1 vORLH"
+    className="styled__ShareButtonContainer-qkwc0r-1 cxdDMy"
   >
     <button
-      className="styled__OutlineButton-qkwc0r-2 ljZNyf"
+      className="styled__OutlineButton-qkwc0r-4 jWKrMk"
     >
       <svg
         aria-hidden="true"
@@ -236,16 +236,16 @@ exports[`save and share bar component save and share bar renders correctly when 
     </button>
     <div
       aria-expanded={false}
-      className="styled__Popover-qkwc0r-3 hRIknm"
+      className="styled__Popover-qkwc0r-5 cMcJTI"
     >
       <div
-        className="styled__PopoverHeader-qkwc0r-4 dwnPtB"
+        className="styled__PopoverHeader-qkwc0r-6 etSOho"
       >
         <h3>
           Share this article
         </h3>
         <button
-          className="styled__CloseButton-qkwc0r-6 drykZc"
+          className="styled__CloseButton-qkwc0r-8 dbcqZq"
         >
           <svg
             fill="none"
@@ -262,7 +262,7 @@ exports[`save and share bar component save and share bar renders correctly when 
         </button>
       </div>
       <div
-        className="styled__PopoverContent-qkwc0r-5 dKaMVi"
+        className="styled__PopoverContent-qkwc0r-7 etEKKi"
       >
         <a
           className="share-item__StyledLink-sc-1idd4zx-2 iTJLEp"

--- a/packages/save-and-share-bar/src/save-and-share-bar.js
+++ b/packages/save-and-share-bar/src/save-and-share-bar.js
@@ -10,7 +10,7 @@ import UserState from "@times-components/user-state";
 import { SectionContext } from "@times-components/context";
 import { SaveStar } from "@times-components/ts-components";
 
-import checkForSymphonyExperiment from "@times-components/utils";
+import { checkForSymphonyExperiment } from "@times-components/utils";
 import getTokenisedArticleUrlApi from "./get-tokenised-article-url-api";
 import withTrackEvents from "./tracking/with-track-events";
 import SharingApiUrls from "./constants";

--- a/packages/save-and-share-bar/src/save-and-share-bar.js
+++ b/packages/save-and-share-bar/src/save-and-share-bar.js
@@ -10,7 +10,7 @@ import UserState from "@times-components/user-state";
 import { SectionContext } from "@times-components/context";
 import { SaveStar } from "@times-components/ts-components";
 
-import { checkForSymphonyExperiment } from "@times-components/utils";
+import checkForSymphonyExperiment from "@times-components/utils";
 import getTokenisedArticleUrlApi from "./get-tokenised-article-url-api";
 import withTrackEvents from "./tracking/with-track-events";
 import SharingApiUrls from "./constants";

--- a/packages/save-and-share-bar/src/save-and-share-bar.js
+++ b/packages/save-and-share-bar/src/save-and-share-bar.js
@@ -10,7 +10,7 @@ import UserState from "@times-components/user-state";
 import { SectionContext } from "@times-components/context";
 import { SaveStar } from "@times-components/ts-components";
 
-import { checkForSymphonyExperiment } from "@times-components/utils/src/check-for-symphony-experiment";
+import { checkForSymphonyExperiment } from "@times-components/utils";
 import getTokenisedArticleUrlApi from "./get-tokenised-article-url-api";
 import withTrackEvents from "./tracking/with-track-events";
 import SharingApiUrls from "./constants";

--- a/packages/save-and-share-bar/src/save-and-share-bar.js
+++ b/packages/save-and-share-bar/src/save-and-share-bar.js
@@ -52,7 +52,6 @@ function SaveAndShareBar(props) {
   const [windowHeight, setWindowHeight] = React.useState(null);
   const [windowWidth, setWindowWidth] = React.useState(null);
   const [shareButtonClicked, setShareButtonClicked] = React.useState(false);
-  const [isSymphonyExperiment, setIsSymphonyExperiment] = React.useState(false);
 
   const barRef = React.useRef();
   const shareBtnRef = React.useRef();
@@ -86,11 +85,6 @@ function SaveAndShareBar(props) {
     };
   }, []);
 
-  useEffect(() => {
-    const isSymphonyExperimentOn = checkForSymphonyExperiment();
-    setIsSymphonyExperiment(isSymphonyExperimentOn);
-  }, []);
-
   const barPosition = barRef.current
     ? barRef.current.getBoundingClientRect().bottom
     : windowHeight;
@@ -115,13 +109,9 @@ function SaveAndShareBar(props) {
     setPopoverOpen(prev => !prev);
   };
 
-  const setShareButtonClickState = () => {
-    setShareButtonClicked(true);
-  };
-
   const handleClick = e => {
     e.preventDefault();
-    setShareButtonClickState();
+    setShareButtonClicked(true);
     togglePopover();
   };
 
@@ -133,14 +123,11 @@ function SaveAndShareBar(props) {
     onCopyLink();
   }
 
-  const showShareButtonHightlight = isSymphonyExperiment && !shareButtonClicked;
+  const isSymphonyExperiment = checkForSymphonyExperiment();
+  const showShareButtonHighlight = isSymphonyExperiment && !shareButtonClicked;
 
   return (
-    <SaveAndShareBarContainer
-      data-testid="save-and-share-bar"
-      ref={barRef}
-      showShareButtonHightlight={showShareButtonHightlight}
-    >
+    <SaveAndShareBarContainer data-testid="save-and-share-bar" ref={barRef}>
       {sharingEnabled && (
         <ShareButtonContainer>
           <OutlineButton
@@ -151,7 +138,7 @@ function SaveAndShareBar(props) {
             <ShareIcon height={14} width={14} />
             Share
           </OutlineButton>
-          {showShareButtonHightlight && (
+          {showShareButtonHighlight && (
             <ShareButtonHighlightContainer data-testId="share-button-highlight">
               <ShareButtonHighlight />
             </ShareButtonHighlightContainer>

--- a/packages/save-and-share-bar/src/save-and-share-bar.js
+++ b/packages/save-and-share-bar/src/save-and-share-bar.js
@@ -113,6 +113,7 @@ function SaveAndShareBar(props) {
     e.preventDefault();
     setShareButtonClicked(true);
     togglePopover();
+    window.localStorage.setItem("hasShareButtonHighlightBeenDismissed", true);
   };
 
   function copyToClipboard(e) {
@@ -124,7 +125,13 @@ function SaveAndShareBar(props) {
   }
 
   const isSymphonyExperiment = checkForSymphonyExperiment();
-  const showShareButtonHighlight = isSymphonyExperiment && !shareButtonClicked;
+  const hasShareButtonHighlightBeenDismissed = window.localStorage.getItem(
+    "hasShareButtonHighlightBeenDismissed"
+  );
+  const showShareButtonHighlight =
+    isSymphonyExperiment &&
+    !shareButtonClicked &&
+    !hasShareButtonHighlightBeenDismissed;
 
   return (
     <SaveAndShareBarContainer data-testid="save-and-share-bar" ref={barRef}>

--- a/packages/save-and-share-bar/src/save-and-share-bar.js
+++ b/packages/save-and-share-bar/src/save-and-share-bar.js
@@ -10,6 +10,7 @@ import UserState from "@times-components/user-state";
 import { SectionContext } from "@times-components/context";
 import { SaveStar } from "@times-components/ts-components";
 
+import { checkForSymphonyExperiment } from "@times-components/utils/src/check-for-symphony-experiment";
 import getTokenisedArticleUrlApi from "./get-tokenised-article-url-api";
 import withTrackEvents from "./tracking/with-track-events";
 import SharingApiUrls from "./constants";
@@ -18,6 +19,8 @@ import styles from "./styles";
 import {
   SaveAndShareBarContainer,
   ShareButtonContainer,
+  ShareButtonHighlightContainer,
+  ShareButtonHighlight,
   OutlineButton,
   Popover,
   PopoverHeader,
@@ -48,6 +51,8 @@ function SaveAndShareBar(props) {
   const [popoverOpen, setPopoverOpen] = React.useState(false);
   const [windowHeight, setWindowHeight] = React.useState(null);
   const [windowWidth, setWindowWidth] = React.useState(null);
+  const [shareButtonClicked, setShareButtonClicked] = React.useState(false);
+  const [isSymphonyExperiment, setIsSymphonyExperiment] = React.useState(false);
 
   const barRef = React.useRef();
   const shareBtnRef = React.useRef();
@@ -81,6 +86,11 @@ function SaveAndShareBar(props) {
     };
   }, []);
 
+  useEffect(() => {
+    const isSymphonyExperimentOn = checkForSymphonyExperiment();
+    setIsSymphonyExperiment(isSymphonyExperimentOn);
+  }, []);
+
   const barPosition = barRef.current
     ? barRef.current.getBoundingClientRect().bottom
     : windowHeight;
@@ -105,6 +115,16 @@ function SaveAndShareBar(props) {
     setPopoverOpen(prev => !prev);
   };
 
+  const setShareButtonClickState = () => {
+    setShareButtonClicked(true);
+  };
+
+  const handleClick = e => {
+    e.preventDefault();
+    setShareButtonClickState();
+    togglePopover();
+  };
+
   function copyToClipboard(e) {
     const { onCopyLink } = props;
     e.preventDefault();
@@ -113,18 +133,29 @@ function SaveAndShareBar(props) {
     onCopyLink();
   }
 
+  const showShareButtonHightlight = isSymphonyExperiment && !shareButtonClicked;
+
   return (
-    <SaveAndShareBarContainer data-testid="save-and-share-bar" ref={barRef}>
+    <SaveAndShareBarContainer
+      data-testid="save-and-share-bar"
+      ref={barRef}
+      showShareButtonHightlight={showShareButtonHightlight}
+    >
       {sharingEnabled && (
         <ShareButtonContainer>
           <OutlineButton
             ref={shareBtnRef}
             isPopoverOpen={popoverOpen}
-            onClick={togglePopover}
+            onClick={handleClick}
           >
             <ShareIcon height={14} width={14} />
             Share
           </OutlineButton>
+          {showShareButtonHightlight && (
+            <ShareButtonHighlightContainer>
+              <ShareButtonHighlight />
+            </ShareButtonHighlightContainer>
+          )}
           <Popover
             ref={popoverRef}
             position={getPosition()}

--- a/packages/save-and-share-bar/src/save-and-share-bar.js
+++ b/packages/save-and-share-bar/src/save-and-share-bar.js
@@ -152,7 +152,7 @@ function SaveAndShareBar(props) {
             Share
           </OutlineButton>
           {showShareButtonHightlight && (
-            <ShareButtonHighlightContainer>
+            <ShareButtonHighlightContainer data-testId="share-button-highlight">
               <ShareButtonHighlight />
             </ShareButtonHighlightContainer>
           )}

--- a/packages/save-and-share-bar/src/styled.js
+++ b/packages/save-and-share-bar/src/styled.js
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { keyframes } from "styled-components";
 
 export const SaveAndShareBarContainer = styled.div`
   display: flex;
@@ -10,7 +10,46 @@ export const SaveAndShareBarContainer = styled.div`
 `;
 
 export const ShareButtonContainer = styled.div`
+  display: flex;
   position: relative;
+`;
+
+const flashing = keyframes`
+  0% {
+    box-shadow: 0;
+  }
+
+  50% {  
+  box-shadow: 0 0 3px 4px #4B9FC950;
+  }
+
+  100% {  
+    box-shadow: 0;
+  }
+`;
+
+export const ShareButtonHighlightContainer = styled.div`
+  display: flex;
+  background-color: #ffffff;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  z-index: 1;
+  position: absolute;
+  top: -5px;
+  right: -5px;
+`;
+
+export const ShareButtonHighlight = styled.div`
+  background-color: #4b9fc9;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  position: absolute;
+  right: -1px;
+  top: -1px;
+  z-index: 2;
+  animation: ${flashing} 2400ms infinite;
 `;
 
 export const OutlineButton = styled.button`

--- a/packages/user-state/src/matchers.js
+++ b/packages/user-state/src/matchers.js
@@ -1,7 +1,11 @@
+import checkForSymphonyExperiment from "@times-components/utils";
 /* User states */
 
+const isSymphonyExperiment = checkForSymphonyExperiment();
+
 const hasAccessLoggedInOrSharedUser = userState =>
-  userState.hasAccess && (userState.isLoggedIn || userState.isShared);
+  (userState.hasAccess && (userState.isLoggedIn || userState.isShared)) ||
+  isSymphonyExperiment;
 
 const hasAccessLoggedInUser = userState =>
   userState.hasAccess && userState.isLoggedIn;

--- a/packages/user-state/src/matchers.js
+++ b/packages/user-state/src/matchers.js
@@ -1,11 +1,7 @@
-import checkForSymphonyExperiment from "@times-components/utils";
 /* User states */
 
-const isSymphonyExperiment = checkForSymphonyExperiment();
-
 const hasAccessLoggedInOrSharedUser = userState =>
-  (userState.hasAccess && (userState.isLoggedIn || userState.isShared)) ||
-  isSymphonyExperiment;
+  userState.hasAccess && (userState.isLoggedIn || userState.isShared);
 
 const hasAccessLoggedInUser = userState =>
   userState.hasAccess && userState.isLoggedIn;

--- a/packages/utils/__tests__/check-for-symphony-experiment.test.js
+++ b/packages/utils/__tests__/check-for-symphony-experiment.test.js
@@ -1,0 +1,60 @@
+import {
+  getCookieValue,
+  getBase64CookieValue,
+  checkForSymphonyExperiment
+} from "../src/check-for-symphony-experiment";
+
+describe("getCookieValue", () => {
+  beforeEach(() => {
+    document.cookie = "testCookie=testValue";
+  });
+
+  it("returns the value of the specified cookie", () => {
+    expect(getCookieValue("testCookie")).toBe("testValue");
+  });
+
+  it("returns null if the cookie is not found", () => {
+    expect(getCookieValue("nonExistentCookie")).toBe(null);
+  });
+});
+
+describe("getBase64CookieValue", () => {
+  beforeEach(() => {
+    const base64Value = btoa(JSON.stringify({ key: "value" }));
+    document.cookie = `base64Cookie=${base64Value}`;
+  });
+
+  it("returns the parsed value of the base64 encoded cookie", () => {
+    expect(getBase64CookieValue("base64Cookie")).toEqual({ key: "value" });
+  });
+
+  it("returns undefined if the cookie is not found", () => {
+    expect(getBase64CookieValue("nonExistentCookie")).toBe(undefined);
+  });
+
+  it("returns undefined if the cookie value is not valid base64", () => {
+    document.cookie = "invalidBase64Cookie=invalidValue";
+    expect(getBase64CookieValue("invalidBase64Cookie")).toBe(undefined);
+  });
+});
+
+describe("checkForSymphonyExperiment", () => {
+  it("returns true if the Symphony experiment is active", () => {
+    const base64Value = btoa(
+      JSON.stringify({ "project-symphony": ["ARTICLE_ACCESS"] })
+    );
+    document.cookie = `nuk_zephr_decisions=${base64Value}`;
+    expect(checkForSymphonyExperiment()).toBe(true);
+  });
+
+  it("returns false if the Symphony experiment is not active", () => {
+    const base64Value = btoa(JSON.stringify({ "project-symphony": [] }));
+    document.cookie = `nuk_zephr_decisions=${base64Value}`;
+    expect(checkForSymphonyExperiment()).toBe(false);
+  });
+
+  it("returns false if the cookie is not found", () => {
+    document.cookie = "nuk_zephr_decisions=";
+    expect(checkForSymphonyExperiment()).toBe(false);
+  });
+});

--- a/packages/utils/__tests__/check-for-symphony-experiment.test.js
+++ b/packages/utils/__tests__/check-for-symphony-experiment.test.js
@@ -3,14 +3,16 @@ import checkForSymphonyExperiment from "../src/check-for-symphony-experiment";
 describe("checkForSymphonyExperiment", () => {
   it("returns true if the Symphony experiment is active", () => {
     const base64Value = btoa(
-      JSON.stringify({ "project-symphony": ["ARTICLE_ACCESS"] })
+      JSON.stringify({ "project-symphony-reg-users": ["ARTICLE_ACCESS"] })
     );
     document.cookie = `nuk_zephr_decisions=${base64Value}`;
     expect(checkForSymphonyExperiment()).toBe(true);
   });
 
   it("returns false if the Symphony experiment is not active", () => {
-    const base64Value = btoa(JSON.stringify({ "project-symphony": [] }));
+    const base64Value = btoa(
+      JSON.stringify({ "project-symphony-reg-users": [] })
+    );
     document.cookie = `nuk_zephr_decisions=${base64Value}`;
     expect(checkForSymphonyExperiment()).toBe(false);
   });

--- a/packages/utils/__tests__/check-for-symphony-experiment.test.js
+++ b/packages/utils/__tests__/check-for-symphony-experiment.test.js
@@ -1,40 +1,4 @@
-import getCookieValue from "../src/get-cookie-value";
-import getBase64CookieValue from "../src/get-base64-cookie-value";
 import checkForSymphonyExperiment from "../src/check-for-symphony-experiment";
-
-describe("getCookieValue", () => {
-  beforeEach(() => {
-    document.cookie = "testCookie=testValue";
-  });
-
-  it("returns the value of the specified cookie", () => {
-    expect(getCookieValue("testCookie")).toBe("testValue");
-  });
-
-  it("returns null if the cookie is not found", () => {
-    expect(getCookieValue("nonExistentCookie")).toBe(null);
-  });
-});
-
-describe("getBase64CookieValue", () => {
-  beforeEach(() => {
-    const base64Value = btoa(JSON.stringify({ key: "value" }));
-    document.cookie = `base64Cookie=${base64Value}`;
-  });
-
-  it("returns the parsed value of the base64 encoded cookie", () => {
-    expect(getBase64CookieValue("base64Cookie")).toEqual({ key: "value" });
-  });
-
-  it("returns undefined if the cookie is not found", () => {
-    expect(getBase64CookieValue("nonExistentCookie")).toBe(undefined);
-  });
-
-  it("returns undefined if the cookie value is not valid base64", () => {
-    document.cookie = "invalidBase64Cookie=invalidValue";
-    expect(getBase64CookieValue("invalidBase64Cookie")).toBe(undefined);
-  });
-});
 
 describe("checkForSymphonyExperiment", () => {
   it("returns true if the Symphony experiment is active", () => {

--- a/packages/utils/__tests__/check-for-symphony-experiment.test.js
+++ b/packages/utils/__tests__/check-for-symphony-experiment.test.js
@@ -1,8 +1,6 @@
-import {
-  getCookieValue,
-  getBase64CookieValue,
-  checkForSymphonyExperiment
-} from "../src/check-for-symphony-experiment";
+import getCookieValue from "../src/get-cookie-value";
+import getBase64CookieValue from "../src/get-base64-cookie-value";
+import checkForSymphonyExperiment from "../src/check-for-symphony-experiment";
 
 describe("getCookieValue", () => {
   beforeEach(() => {

--- a/packages/utils/__tests__/check-for-symphony-experiment.test.js
+++ b/packages/utils/__tests__/check-for-symphony-experiment.test.js
@@ -3,16 +3,14 @@ import checkForSymphonyExperiment from "../src/check-for-symphony-experiment";
 describe("checkForSymphonyExperiment", () => {
   it("returns true if the Symphony experiment is active", () => {
     const base64Value = btoa(
-      JSON.stringify({ "project-symphony-reg-users": ["ARTICLE_ACCESS"] })
+      JSON.stringify({ "free-access-symphony": ["ARTICLE_ACCESS"] })
     );
     document.cookie = `nuk_zephr_decisions=${base64Value}`;
     expect(checkForSymphonyExperiment()).toBe(true);
   });
 
   it("returns false if the Symphony experiment is not active", () => {
-    const base64Value = btoa(
-      JSON.stringify({ "project-symphony-reg-users": [] })
-    );
+    const base64Value = btoa(JSON.stringify({ "free-access-symphony": [] }));
     document.cookie = `nuk_zephr_decisions=${base64Value}`;
     expect(checkForSymphonyExperiment()).toBe(false);
   });

--- a/packages/utils/__tests__/get-base64-cookie-value.test.js
+++ b/packages/utils/__tests__/get-base64-cookie-value.test.js
@@ -1,0 +1,21 @@
+import getBase64CookieValue from "../src/get-base64-cookie-value";
+
+describe("getBase64CookieValue", () => {
+  beforeEach(() => {
+    const base64Value = btoa(JSON.stringify({ key: "value" }));
+    document.cookie = `base64Cookie=${base64Value}`;
+  });
+
+  it("returns the parsed value of the base64 encoded cookie", () => {
+    expect(getBase64CookieValue("base64Cookie")).toEqual({ key: "value" });
+  });
+
+  it("returns undefined if the cookie is not found", () => {
+    expect(getBase64CookieValue("nonExistentCookie")).toBe(undefined);
+  });
+
+  it("returns undefined if the cookie value is not valid base64", () => {
+    document.cookie = "invalidBase64Cookie=invalidValue";
+    expect(getBase64CookieValue("invalidBase64Cookie")).toBe(undefined);
+  });
+});

--- a/packages/utils/__tests__/get-cookie-value.test.js
+++ b/packages/utils/__tests__/get-cookie-value.test.js
@@ -1,0 +1,15 @@
+import getCookieValue from "../src/get-cookie-value";
+
+describe("getCookieValue", () => {
+  beforeEach(() => {
+    document.cookie = "testCookie=testValue";
+  });
+
+  it("returns the value of the specified cookie", () => {
+    expect(getCookieValue("testCookie")).toBe("testValue");
+  });
+
+  it("returns null if the cookie is not found", () => {
+    expect(getCookieValue("nonExistentCookie")).toBe(null);
+  });
+});

--- a/packages/utils/src/check-for-symphony-experiment.js
+++ b/packages/utils/src/check-for-symphony-experiment.js
@@ -1,0 +1,21 @@
+export const getCookieValue = cookieName => {
+  const allCookies = document.cookie;
+  const cookiesArray = allCookies.split(";");
+  const targetCookie = cookiesArray.find(cookie => cookie.includes(cookieName));
+  return targetCookie && targetCookie.split("=")[1];
+};
+
+export const getBase64CookieValue = cookieName => {
+  const cookieValue = getCookieValue(cookieName);
+  if (!cookieValue) return undefined;
+  try {
+    return JSON.parse(atob(cookieValue));
+  } catch (e) {
+    return undefined;
+  }
+};
+
+export const checkForSymphonyExperiment = () => {
+  const zephrDecisions = getBase64CookieValue("nuk_zephr_decisions");
+  return !!zephrDecisions?.["project-symphony"]?.includes("ARTICLE_ACCESS");
+};

--- a/packages/utils/src/check-for-symphony-experiment.js
+++ b/packages/utils/src/check-for-symphony-experiment.js
@@ -1,21 +1,8 @@
-export const getCookieValue = cookieName => {
-  const allCookies = document.cookie;
-  const cookiesArray = allCookies.split(";");
-  const targetCookie = cookiesArray.find(cookie => cookie.includes(cookieName));
-  return targetCookie ? targetCookie.split("=")[1] : null;
-};
+import getBase64CookieValue from "./get-base64-cookie-value";
 
-export const getBase64CookieValue = cookieName => {
-  const cookieValue = getCookieValue(cookieName);
-  if (!cookieValue) return undefined;
-  try {
-    return JSON.parse(atob(cookieValue));
-  } catch (e) {
-    return undefined;
-  }
-};
-
-export const checkForSymphonyExperiment = () => {
+const checkForSymphonyExperiment = () => {
   const zephrDecisions = getBase64CookieValue("nuk_zephr_decisions");
   return !!zephrDecisions?.["project-symphony"]?.includes("ARTICLE_ACCESS");
 };
+
+export default checkForSymphonyExperiment;

--- a/packages/utils/src/check-for-symphony-experiment.js
+++ b/packages/utils/src/check-for-symphony-experiment.js
@@ -2,7 +2,7 @@ export const getCookieValue = cookieName => {
   const allCookies = document.cookie;
   const cookiesArray = allCookies.split(";");
   const targetCookie = cookiesArray.find(cookie => cookie.includes(cookieName));
-  return targetCookie && targetCookie.split("=")[1];
+  return targetCookie ? targetCookie.split("=")[1] : null;
 };
 
 export const getBase64CookieValue = cookieName => {

--- a/packages/utils/src/check-for-symphony-experiment.js
+++ b/packages/utils/src/check-for-symphony-experiment.js
@@ -2,10 +2,12 @@ import getBase64CookieValue from "./get-base64-cookie-value";
 
 const checkForSymphonyExperiment = () => {
   const zephrDecisions = getBase64CookieValue("nuk_zephr_decisions");
-  if (!zephrDecisions || !zephrDecisions["project-symphony"]) {
+  if (!zephrDecisions || !zephrDecisions["project-symphony-reg-users"]) {
     return false;
   }
-  return zephrDecisions["project-symphony"].includes("ARTICLE_ACCESS");
+  return zephrDecisions["project-symphony-reg-users"].includes(
+    "ARTICLE_ACCESS"
+  );
 };
 
 export default checkForSymphonyExperiment;

--- a/packages/utils/src/check-for-symphony-experiment.js
+++ b/packages/utils/src/check-for-symphony-experiment.js
@@ -2,12 +2,10 @@ import getBase64CookieValue from "./get-base64-cookie-value";
 
 const checkForSymphonyExperiment = () => {
   const zephrDecisions = getBase64CookieValue("nuk_zephr_decisions");
-  if (!zephrDecisions || !zephrDecisions["project-symphony-reg-users"]) {
+  if (!zephrDecisions || !zephrDecisions["free-access-symphony"]) {
     return false;
   }
-  return zephrDecisions["project-symphony-reg-users"].includes(
-    "ARTICLE_ACCESS"
-  );
+  return zephrDecisions["free-access-symphony"].includes("ARTICLE_ACCESS");
 };
 
 export default checkForSymphonyExperiment;

--- a/packages/utils/src/check-for-symphony-experiment.js
+++ b/packages/utils/src/check-for-symphony-experiment.js
@@ -2,7 +2,10 @@ import getBase64CookieValue from "./get-base64-cookie-value";
 
 const checkForSymphonyExperiment = () => {
   const zephrDecisions = getBase64CookieValue("nuk_zephr_decisions");
-  return !!zephrDecisions?.["project-symphony"]?.includes("ARTICLE_ACCESS");
+  if (!zephrDecisions || !zephrDecisions["project-symphony"]) {
+    return false;
+  }
+  return zephrDecisions["project-symphony"].includes("ARTICLE_ACCESS");
 };
 
 export default checkForSymphonyExperiment;

--- a/packages/utils/src/get-base64-cookie-value.js
+++ b/packages/utils/src/get-base64-cookie-value.js
@@ -1,0 +1,13 @@
+import getCookieValue from "./get-cookie-value";
+
+const getBase64CookieValue = cookieName => {
+  const cookieValue = getCookieValue(cookieName);
+  if (!cookieValue) return undefined;
+  try {
+    return JSON.parse(atob(cookieValue));
+  } catch (e) {
+    return undefined;
+  }
+};
+
+export default getBase64CookieValue;

--- a/packages/utils/src/get-cookie-value.js
+++ b/packages/utils/src/get-cookie-value.js
@@ -1,0 +1,8 @@
+const getCookieValue = cookieName => {
+  const allCookies = document.cookie;
+  const cookiesArray = allCookies.split(";");
+  const targetCookie = cookiesArray.find(cookie => cookie.includes(cookieName));
+  return targetCookie ? targetCookie.split("=")[1] : null;
+};
+
+export default getCookieValue;

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -26,3 +26,4 @@ export { default as TcScrollView } from "./tc-scroll-view";
 export {
   default as CanShowPuzzleSidebar
 } from "./article-puzzle-sidebar-whitelist";
+export { getCookieValue, getBase64CookieValue, checkForSymphonyExperiment } from './check-for-symphony-experiment';

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -26,8 +26,8 @@ export { default as TcScrollView } from "./tc-scroll-view";
 export {
   default as CanShowPuzzleSidebar
 } from "./article-puzzle-sidebar-whitelist";
+export { default as getCookieValue } from "./get-cookie-value";
+export { default as getBase64CookieValue } from "./get-base64-cookie-value";
 export {
-  getCookieValue,
-  getBase64CookieValue,
-  checkForSymphonyExperiment
+  default as checkForSymphonyExperiment
 } from "./check-for-symphony-experiment";

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -26,4 +26,8 @@ export { default as TcScrollView } from "./tc-scroll-view";
 export {
   default as CanShowPuzzleSidebar
 } from "./article-puzzle-sidebar-whitelist";
-export { getCookieValue, getBase64CookieValue, checkForSymphonyExperiment } from './check-for-symphony-experiment';
+export {
+  getCookieValue,
+  getBase64CookieValue,
+  checkForSymphonyExperiment
+} from "./check-for-symphony-experiment";


### PR DESCRIPTION
### Description

During Project Symphony, when all articles will be open to all users, we would like to emphasise the "share" feature on articles. This PR adds a flashing blue dot to the share button and logic to only show it during Project Symphony (as determined by the `nuk_zephr_decisions` cookie) and only before the button is clicked. Once the share button has been clicked the blue dot should no longer be visible.

[TMG-3003](https://nidigitalsolutions.jira.com/browse/TMG-3003)

### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Without the blue dot:
![image](https://github.com/user-attachments/assets/55762da7-7463-4fd5-89ca-e56da3209233)

With the blue dot:
![image](https://github.com/user-attachments/assets/e3142543-87be-4e00-9219-c33e50449c1e)




[TMG-3003]: https://nidigitalsolutions.jira.com/browse/TMG-3003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ