### PR TITLE
feat(TMG-000): Remove SaveAndShareBar UserState logic

### DIFF
--- a/packages/article-extras/src/article-extras.js
+++ b/packages/article-extras/src/article-extras.js
@@ -123,24 +123,22 @@ const ArticleExtras = ({
       {renderBreadcrumb({ showBorder: topics && topics.length > 0 })}
       <ArticleTopics topics={topics} />
       {isSharingSavingEnabled && (
-        <UserState state={UserState.showSaveAndShareBar}>
-          <MessageContext.Consumer>
-            {({ showMessage }) => (
-              <ShareAndSaveContainer showBottomBorder={!relatedArticleSlice}>
-                <SaveAndShareBar
-                  articleId={articleId}
-                  articleHeadline={articleHeadline}
-                  articleUrl={articleUrl}
-                  onCopyLink={() => showMessage("Article link copied")}
-                  onSaveToMyArticles={() => {}}
-                  onShareOnEmail={() => {}}
-                  savingEnabled={savingEnabled}
-                  sharingEnabled={sharingEnabled}
-                />
-              </ShareAndSaveContainer>
-            )}
-          </MessageContext.Consumer>
-        </UserState>
+        <MessageContext.Consumer>
+          {({ showMessage }) => (
+            <ShareAndSaveContainer showBottomBorder={!relatedArticleSlice}>
+              <SaveAndShareBar
+                articleId={articleId}
+                articleHeadline={articleHeadline}
+                articleUrl={articleUrl}
+                onCopyLink={() => showMessage("Article link copied")}
+                onSaveToMyArticles={() => {}}
+                onShareOnEmail={() => {}}
+                savingEnabled={savingEnabled}
+                sharingEnabled={sharingEnabled}
+              />
+            </ShareAndSaveContainer>
+          )}
+        </MessageContext.Consumer>
       )}
       {sponsoredArticlesAndRelatedArticles(true, false)}
       <ArticleComments

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -332,23 +332,21 @@ const ArticleSkeleton = ({
                 )}
                 <Header />
                 {isSharingSavingEnabled ? (
-                  <UserState state={UserState.showSaveAndShareBar}>
-                    <MessageContext.Consumer>
-                      {({ showMessage }) => (
-                        <StickySaveAndShareBar
-                          articleId={articleId}
-                          articleHeadline={headline}
-                          articleUrl={articleUrl}
-                          onCopyLink={() => showMessage("Article link copied")}
-                          onSaveToMyArticles={() => {}}
-                          onShareOnEmail={() => {}}
-                          savingEnabled={savingEnabled}
-                          sharingEnabled={sharingEnabled}
-                          hostName={domainSpecificUrl}
-                        />
-                      )}
-                    </MessageContext.Consumer>
-                  </UserState>
+                  <MessageContext.Consumer>
+                    {({ showMessage }) => (
+                      <StickySaveAndShareBar
+                        articleId={articleId}
+                        articleHeadline={headline}
+                        articleUrl={articleUrl}
+                        onCopyLink={() => showMessage("Article link copied")}
+                        onSaveToMyArticles={() => {}}
+                        onShareOnEmail={() => {}}
+                        savingEnabled={savingEnabled}
+                        sharingEnabled={sharingEnabled}
+                        hostName={domainSpecificUrl}
+                      />
+                    )}
+                  </MessageContext.Consumer>
                 ) : null}
                 {!!zephrDivs && (
                   <StaticContent


### PR DESCRIPTION
### Description

It has been decided that we want all users to see the share button.

This PR removes the `<UserState>` wrapper around the `<SaveAndShareBar>`.


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
