### PR TITLE
fix(TMRA-193): fix newsletter signup typo

### DIFF
--- a/packages/ts-components/src/components/newsletter-puff/__tests__/__snapshots__/InlineNewsletterPuff.test.tsx.snap
+++ b/packages/ts-components/src/components/newsletter-puff/__tests__/__snapshots__/InlineNewsletterPuff.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Inline Newsletter Puff renders loading state state 1`] = `
         <div
           class="sc-bxivhb sc-gqjmRU kcwRFH"
         >
-          You've succesfully signed up to
+          You've successfully signed up to the
            
           <div
             class="sc-bxivhb sc-gZMcBi bklePC"

--- a/packages/ts-components/src/components/newsletter-puff/newsletter/Newsletter.tsx
+++ b/packages/ts-components/src/components/newsletter-puff/newsletter/Newsletter.tsx
@@ -57,7 +57,7 @@ export const Newsletter = ({
         {loading && <LoadingOverlay />}
         {!error &&
           justSubscribed && (
-            <InpSubscribedContainer>    
+            <InpSubscribedContainer>
               <InpCopy>
                 You've successfully signed up to the{' '}
                 <InpSignupHeadline>{`${headline}.`} </InpSignupHeadline>

--- a/packages/ts-components/src/components/newsletter-puff/newsletter/Newsletter.tsx
+++ b/packages/ts-components/src/components/newsletter-puff/newsletter/Newsletter.tsx
@@ -57,9 +57,9 @@ export const Newsletter = ({
         {loading && <LoadingOverlay />}
         {!error &&
           justSubscribed && (
-            <InpSubscribedContainer>
+            <InpSubscribedContainer>    
               <InpCopy>
-                You've succesfully signed up to{' '}
+                You've successfully signed up to the{' '}
                 <InpSignupHeadline>{`${headline}.`} </InpSignupHeadline>
                 <NewsletterPuffLink />
               </InpCopy>


### PR DESCRIPTION
### Description

Please include a summary of the change along with relevant motivation and context.

[TMRA-193](https://nidigitalsolutions.jira.com/browse/TMRA-193)
This one fixes a typo (`succesfully`) and adds `the` on signup to newsletter.
`You've succesfully signed up to` is now `You've successfully signed up to the`

<img width="1896" alt="Screenshot 2025-04-28 at 13 34 08" src="https://github.com/user-attachments/assets/08b2f917-b421-4689-9195-cb7a25cc35fb" />


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.


[TMRA-193]: https://nidigitalsolutions.jira.com/browse/TMRA-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ