### PR TITLE
chore(TMW-000): Remove teaser article extras

### DIFF
--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -464,32 +464,34 @@ const ArticleSkeleton = ({
                       </PaywallPortal>
                     </ArticleContent>
                   </ArticleWrapper>
-                  <LazyLoad rootMargin={spacing(40)} threshold={0}>
-                    {({ observed, registerNode }) => (
-                      <ArticleExtras
-                        analyticsStream={analyticsStream}
-                        articleId={articleId}
-                        articleHeadline={headline}
-                        articleUrl={articleUrl}
-                        section={section}
-                        publishedTime={publishedTime}
-                        savingEnabled={savingEnabled}
-                        sharingEnabled={sharingEnabled}
-                        commentsEnabled={commentsEnabled}
-                        registerNode={registerNode}
-                        relatedArticleSlice={relatedArticleSlice}
-                        categorisedArticles={categorisedArticles}
-                        relatedArticlesVisible={
-                          !!observed.get("related-articles")
-                        }
-                        commentingConfig={commentingConfig}
-                        topics={topics}
-                        breadcrumbs={breadcrumbs}
-                        domainSpecificUrl={domainSpecificUrl}
-                        isWebPFormatActive={isWebPFormatActive}
-                      />
-                    )}
-                  </LazyLoad>
+                  {!removeTeaserContent && (
+                    <LazyLoad rootMargin={spacing(40)} threshold={0}>
+                      {({ observed, registerNode }) => (
+                        <ArticleExtras
+                          analyticsStream={analyticsStream}
+                          articleId={articleId}
+                          articleHeadline={headline}
+                          articleUrl={articleUrl}
+                          section={section}
+                          publishedTime={publishedTime}
+                          savingEnabled={savingEnabled}
+                          sharingEnabled={sharingEnabled}
+                          commentsEnabled={commentsEnabled}
+                          registerNode={registerNode}
+                          relatedArticleSlice={relatedArticleSlice}
+                          categorisedArticles={categorisedArticles}
+                          relatedArticlesVisible={
+                            !!observed.get("related-articles")
+                          }
+                          commentingConfig={commentingConfig}
+                          topics={topics}
+                          breadcrumbs={breadcrumbs}
+                          domainSpecificUrl={domainSpecificUrl}
+                          isWebPFormatActive={isWebPFormatActive}
+                        />
+                      )}
+                    </LazyLoad>
+                  )}
                   {!!zephrDivs && (
                     <StaticContent
                       html={


### PR DESCRIPTION
### Description

If the `removeTeaserContent` feature flag is active - remove all content from the teaser article page.


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
