### PR TITLE
fix(TMRA-264): resolve cssSelector value on in-depth template

### DIFF
--- a/packages/article-in-depth/src/article-in-depth.js
+++ b/packages/article-in-depth/src/article-in-depth.js
@@ -81,6 +81,7 @@ class ArticlePage extends Component {
       receiveChildList,
       commentingConfig,
       articleDataFromRender,
+      paidContentClassName,
       isPreview,
       swgProductId,
       removeTeaserContent
@@ -100,6 +101,7 @@ class ArticlePage extends Component {
         navigationMode={navigationMode}
         commentingConfig={commentingConfig}
         articleDataFromRender={articleDataFromRender}
+        paidContentClassName={paidContentClassName}
         isPreview={isPreview}
         swgProductId={swgProductId}
         removeTeaserContent={removeTeaserContent}


### PR DESCRIPTION
### Description

add `paidContentClassName` parameter to resolve value for `cssSelector` in article-in-depth template.
[TMRA-264](https://nidigitalsolutions.jira.com/browse/TMRA-264)


### Checklist

- [ ] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.


[TMRA-264]: https://nidigitalsolutions.jira.com/browse/TMRA-264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ