### PR TITLE
fix(TMPR-359): update breadcrumblist page metadata with valid URLs

### DIFF
--- a/packages/article-main-video/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-video/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -99,7 +99,7 @@ exports[`1. an article 1`] = `
         <script
           type="application/ld+json"
         >
-          {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Comment","item":"https://www.thetimes.co.uk/undefined"},{"@type":"ListItem","position":2,"name":"News","item":"https://www.thetimes.co.uk/undefined"}]}
+          {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Comment","item":"https://www.thetimes.co.uk/comment"},{"@type":"ListItem","position":2,"name":"News","item":"https://www.thetimes.co.uk/news"}]}
         </script>
         <script
           defer={true}

--- a/packages/article-skeleton/src/head.js
+++ b/packages/article-skeleton/src/head.js
@@ -380,7 +380,7 @@ function Head({
             "@type": "ListItem",
             position: breadcrumbIndex + 1,
             name: breadcrumb.title,
-            item: `${domainSpecificUrl}/${breadcrumb.slug}`
+            item: `${domainSpecificUrl}${breadcrumb.url}`
           }))
         }
       : null;


### PR DESCRIPTION
### Description

As part of some analysis in GSC we spotted that the breadcrumblist metadata on article pages have undefined URLs

eg  [Foreign Office staff told to resign if they don’t like Gaza stance](https://www.thetimes.com/uk/politics/article/foreign-office-staff-told-to-resign-if-they-dont-like-gaza-stance-dzdm3bl3r)

The L1/ Ln structure is correct but for each level, the URL given is undefined

{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Travel","item":"https://www.thetimes.com/undefined"},{"@type":"ListItem","position":2,"name":"Destinations","item":"https://www.thetimes.com/undefined"},{"@type":"ListItem","position":3,"name":"Europe","item":"https://www.thetimes.com/undefined"},{"@type":"ListItem","position":4,"name":"Cyprus","item":"https://www.thetimes.com/undefined"}]}

The breadcrumb on the page itself is correct and does have the correct URLs

image-20250610-133343.png
This was the spike ticket  https://nidigitalsolutions.jira.com/issues/TMRX-1710 and the spike results  
[Spike: TMRX-1710 - How might we display breadcrumb component on articles](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/4638015639/Spike+TMRX-1710+-+How+might+we+display+breadcrumb+component+on+articles) 

 

We need to fix this so the page metadata URLs match the valid on page navigation links

@Michael Douglas has done some initial investiagtion and should be a quick fix:

We previously used breadcrumb.slug to populate this field, but this was changed when we passed our breadcrumbs from Render to TC for the article. It now uses, or should use, breadcrumb.url within this code[times-components/packages/article-skeleton/src/head.js at master · newsuk/times-components](https://github.com/newsuk/times-components/blob/master/packages/article-skeleton/src/head.js#L383) 

Acceptance Criteria


Article pages should have breadcrumb metadata with valid URL paths instead of  "https://www.thetimes.com/undefined"
[JIRA-359](https://nidigitalsolutions.jira.com/browse/TMPR-359)


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

