### PR TITLE
fix(TMPR-520): add missing description to live blog articles

### DIFF
--- a/packages/article-skeleton/src/head.js
+++ b/packages/article-skeleton/src/head.js
@@ -190,7 +190,8 @@ const getLiveBlogUpdates = (
                       contentObj[i].attributes.title ||
                       update.headline ||
                       "Video",
-                    description: contentObj[i].attributes.caption,
+                    description:
+                      contentObj[i].attributes.caption || update.description,
                     uploadDate:
                       contentObj[i].attributes.updated || update.datePublished,
                     thumbnailUrl: contentObj[i].attributes.posterImageUrl,

--- a/packages/article-skeleton/src/head.js
+++ b/packages/article-skeleton/src/head.js
@@ -122,8 +122,7 @@ const getLiveBlogUpdates = (
   publisher,
   author,
   isLiveArticleMetaDataEnabled,
-  seoDescription,
-  descriptionMarkup
+  desc
 ) => {
   const updates = [];
   if (article === null) {
@@ -192,13 +191,7 @@ const getLiveBlogUpdates = (
                       contentObj[i].attributes.title ||
                       update.headline ||
                       "Video",
-                    description:
-                      contentObj[i].attributes.caption ||
-                      seoDescription ||
-                      (Array.isArray(descriptionMarkup) &&
-                      descriptionMarkup.length
-                        ? renderTreeAsText({ children: descriptionMarkup })
-                        : null),
+                    description: contentObj[i].attributes.caption || desc,
                     uploadDate:
                       contentObj[i].attributes.updated || update.datePublished,
                     thumbnailUrl: contentObj[i].attributes.posterImageUrl,
@@ -320,8 +313,7 @@ function Head({
     publisherSchema,
     authorSchema,
     isLiveArticleMetaDataEnabled,
-    seoDescription,
-    descriptionMarkup
+    desc
   );
 
   const jsonLD = {

--- a/packages/article-skeleton/src/head.js
+++ b/packages/article-skeleton/src/head.js
@@ -121,7 +121,9 @@ const getLiveBlogUpdates = (
   article,
   publisher,
   author,
-  isLiveArticleMetaDataEnabled
+  isLiveArticleMetaDataEnabled,
+  seoDescription,
+  descriptionMarkup
 ) => {
   const updates = [];
   if (article === null) {
@@ -191,7 +193,12 @@ const getLiveBlogUpdates = (
                       update.headline ||
                       "Video",
                     description:
-                      contentObj[i].attributes.caption || update.description,
+                      contentObj[i].attributes.caption ||
+                      seoDescription ||
+                      (Array.isArray(descriptionMarkup) &&
+                      descriptionMarkup.length
+                        ? renderTreeAsText({ children: descriptionMarkup })
+                        : null),
                     uploadDate:
                       contentObj[i].attributes.updated || update.datePublished,
                     thumbnailUrl: contentObj[i].attributes.posterImageUrl,
@@ -312,7 +319,9 @@ function Head({
     article,
     publisherSchema,
     authorSchema,
-    isLiveArticleMetaDataEnabled
+    isLiveArticleMetaDataEnabled,
+    seoDescription,
+    descriptionMarkup
   );
 
   const jsonLD = {


### PR DESCRIPTION
### Description

The Live blogs are seeing less traffic than usual and Google Search Console is reporting Crawl issues which could be the cause of the issue.

We need to ensure that all articles crawled have no issues. In particular the Live Blog articles which are critical for converting traffic into paid subscribers.

The videos posts within the live blogs articles should all have the Missing or recommended fields.

Currently, the description field is missing from video posts within Live Blog articles. This ticket is to add that field to resolve the following warning:

Missing field 'description' (optional)

Acceptance Criteria


Live Blogs need to have all missing attributes

Missing field 'uploadDate'

Missing field 'name'

Missing field 'thumbnailUrl'

Missing field 'description' (optional)

Either 'contentUrl' or 'embedUrl' should be specified (optional)
[JIRA-520](https://nidigitalsolutions.jira.com/browse/TMPR-520)


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?
