### PR TITLE
feat(TMPR-614): update profile pages schema

### DIFF
--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile-loading.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile-loading.web.test.js.snap
@@ -14,7 +14,7 @@ exports[`1. an article list loading with images 1`] = `
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"CollectionPage","publisher":{"@type":"Organization","name":"The Times","logo":{"@type":"ImageObject","url":"/d/assets/dual-masthead-6a9822c61a.png","width":"600","height":"315"}},"headline":"","description":"Get up to date information and read all the latest articles from .","url":"https://www.thetimes.com/profile/some-slug","mainEntity":{"@type":"ItemList","itemListElement":[]},"isAccessibleForFree":true,"articleSection":"author profile page"}
+      {"@context":"https://schema.org","@type":"ProfilePage","mainEntity":{"@type":"Person","description":"Get up to date information and read all the latest articles from .","image":"","jobTitle":"","name":"","url":"https://www.thetimes.com/profile/some-slug"}}
     </script>
   </Helmet>
   <ArticleList
@@ -53,7 +53,7 @@ exports[`2. an article list loading without images 1`] = `
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"CollectionPage","publisher":{"@type":"Organization","name":"The Times","logo":{"@type":"ImageObject","url":"/d/assets/dual-masthead-6a9822c61a.png","width":"600","height":"315"}},"headline":"","description":"Get up to date information and read all the latest articles from .","url":"https://www.thetimes.com/profile/some-slug","mainEntity":{"@type":"ItemList","itemListElement":[]},"isAccessibleForFree":true,"articleSection":"author profile page"}
+      {"@context":"https://schema.org","@type":"ProfilePage","mainEntity":{"@type":"Person","description":"Get up to date information and read all the latest articles from .","image":"","jobTitle":"","name":"","url":"https://www.thetimes.com/profile/some-slug"}}
     </script>
   </Helmet>
   <ArticleList

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
@@ -16,7 +16,7 @@ exports[`2. a loading state 1`] = `
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"CollectionPage","publisher":{"@type":"Organization","name":"The Times","logo":{"@type":"ImageObject","url":"/d/assets/dual-masthead-6a9822c61a.png","width":"600","height":"315"}},"headline":"","description":"Get up to date information and read all the latest articles from .","url":"https://www.thetimes.com/profile/some-slug","mainEntity":{"@type":"ItemList","itemListElement":[{"@type":"ListItem","url":"https://article1.io","position":1}]},"isAccessibleForFree":true,"articleSection":"author profile page"}
+      {"@context":"https://schema.org","@type":"ProfilePage","mainEntity":{"@type":"Person","description":"Get up to date information and read all the latest articles from .","image":"","jobTitle":"","name":"","url":"https://www.thetimes.com/profile/some-slug"}}
     </script>
   </Helmet>
   <ArticleList
@@ -64,7 +64,7 @@ exports[`3. an article list with images 1`] = `
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"CollectionPage","publisher":{"@type":"Organization","name":"The Times","logo":{"@type":"ImageObject","url":"/d/assets/dual-masthead-6a9822c61a.png","width":"600","height":"315"}},"headline":"Name","description":"Camilla Long","url":"https://www.thetimes.com/profile/some-slug","mainEntity":{"@type":"ItemList","itemListElement":[{"@type":"ListItem","url":"https://article1.io","position":1}]},"isAccessibleForFree":true,"articleSection":"author profile page"}
+      {"@context":"https://schema.org","@type":"ProfilePage","mainEntity":{"@type":"Person","description":"Camilla Long","image":"https://image.io","jobTitle":"Job Title","name":"Name","url":"https://www.thetimes.com/profile/some-slug"}}
     </script>
   </Helmet>
   <ArticleList
@@ -123,7 +123,7 @@ exports[`4. an article list without images 1`] = `
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"CollectionPage","publisher":{"@type":"Organization","name":"The Times","logo":{"@type":"ImageObject","url":"/d/assets/dual-masthead-6a9822c61a.png","width":"600","height":"315"}},"headline":"Name","description":"Camilla Long","url":"https://www.thetimes.com/profile/some-slug","mainEntity":{"@type":"ItemList","itemListElement":[{"@type":"ListItem","url":"https://article1.io","position":1}]},"isAccessibleForFree":true,"articleSection":"author profile page"}
+      {"@context":"https://schema.org","@type":"ProfilePage","mainEntity":{"@type":"Person","description":"Camilla Long","image":"","jobTitle":"Job Title","name":"Name","url":"https://www.thetimes.com/profile/some-slug"}}
     </script>
   </Helmet>
   <ArticleList
@@ -182,7 +182,7 @@ exports[`5. fetches more articles 1`] = `
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"CollectionPage","publisher":{"@type":"Organization","name":"The Times","logo":{"@type":"ImageObject","url":"/d/assets/dual-masthead-6a9822c61a.png","width":"600","height":"315"}},"headline":"Name","description":"Camilla Long","url":"https://www.thetimes.com/profile/some-slug","mainEntity":{"@type":"ItemList","itemListElement":[{"@type":"ListItem","url":"https://article1.io","position":1},{"@type":"ListItem","url":"https://article3.io","position":2}]},"isAccessibleForFree":true,"articleSection":"author profile page"}
+      {"@context":"https://schema.org","@type":"ProfilePage","mainEntity":{"@type":"Person","description":"Camilla Long","image":"https://image.io","jobTitle":"Job Title","name":"Name","url":"https://www.thetimes.com/profile/some-slug"}}
     </script>
   </Helmet>
   <ArticleList
@@ -246,7 +246,7 @@ exports[`6. fetches more articles and falls back to previous data if no more 1`]
     <script
       type="application/ld+json"
     >
-      {"@context":"http://schema.org","@type":"CollectionPage","publisher":{"@type":"Organization","name":"The Times","logo":{"@type":"ImageObject","url":"/d/assets/dual-masthead-6a9822c61a.png","width":"600","height":"315"}},"headline":"Name","description":"Camilla Long","url":"https://www.thetimes.com/profile/some-slug","mainEntity":{"@type":"ItemList","itemListElement":[{"@type":"ListItem","url":"https://article1.io","position":1}]},"isAccessibleForFree":true,"articleSection":"author profile page"}
+      {"@context":"https://schema.org","@type":"ProfilePage","mainEntity":{"@type":"Person","description":"Camilla Long","image":"https://image.io","jobTitle":"Job Title","name":"Name","url":"https://www.thetimes.com/profile/some-slug"}}
     </script>
   </Helmet>
   <ArticleList

--- a/packages/author-profile/src/author-profile.js
+++ b/packages/author-profile/src/author-profile.js
@@ -119,7 +119,8 @@ const AuthorProfile = ({
               description={biography}
               name={name}
               slug={slug}
-              articles={get(data, "articles.list", [])}
+              jobTitle={jobTitle}
+              uri={uri}
             />
             <ArticleList
               articleListHeader={articleListHeader}

--- a/packages/author-profile/src/head.js
+++ b/packages/author-profile/src/head.js
@@ -5,7 +5,7 @@ import { renderTreeArrayAsText } from "@times-components/markup-forest";
 
 import { propTypes as authorProfileHeadPropTypes } from "./author-profile-head-prop-types";
 
-function Head({ metaDescription, description, name, slug, articles }) {
+function Head({ metaDescription, description, name, slug, jobTitle, uri }) {
   let content = `Get up to date information and read all the latest articles from ${name}.`;
 
   if (metaDescription) {
@@ -20,32 +20,16 @@ function Head({ metaDescription, description, name, slug, articles }) {
       <meta content={content} name="description" />
       <script type="application/ld+json">
         {JSON.stringify({
-          "@context": "http://schema.org",
-          "@type": "CollectionPage",
-          publisher: {
-            "@type": "Organization",
-            name: "The Times",
-            logo: {
-              "@type": "ImageObject",
-              url: "/d/assets/dual-masthead-6a9822c61a.png",
-              width: "600",
-              height: "315"
-            }
-          },
-
-          headline: name,
-          description: content,
-          url: `https://www.thetimes.com/profile/${slug}`,
+          "@context": "https://schema.org",
+          "@type": "ProfilePage",
           mainEntity: {
-            "@type": "ItemList",
-            itemListElement: articles.map((article, index) => ({
-              "@type": "ListItem",
-              url: article.url,
-              position: index + 1
-            }))
-          },
-          isAccessibleForFree: true,
-          articleSection: "author profile page"
+            "@type": "Person",
+            description: content,
+            image: uri,
+            jobTitle,
+            name,
+            url: `https://www.thetimes.com/profile/${slug}`
+          }
         })}
       </script>
     </Helmet>
@@ -57,17 +41,15 @@ Head.propTypes = {
   description: authorProfileHeadPropTypes.biography.isRequired,
   name: PropTypes.string.isRequired,
   slug: PropTypes.string,
-  articles: PropTypes.arrayOf(
-    PropTypes.shape({
-      url: PropTypes.string
-    })
-  )
+  jobTitle: PropTypes.string,
+  uri: PropTypes.string
 };
 
 Head.defaultProps = {
   metaDescription: null,
   slug: "",
-  articles: []
+  jobTitle: "",
+  uri: ""
 };
 
 export default Head;


### PR DESCRIPTION
### Description

Profile pages should implement the ProfilePage schema in JSON-LD format, following [Google’s official guidelines](https://developers.google.com/search/docs/appearance/structured-data/profile-page). This ensures that profile content is eligible for enhanced search features and meets SEO best practices

Acceptance Criteria


Profile pages should include the suggested Profile schema using valid JSON-LD

```
{
  "@context": "https://schema.org ",
  "@type": "ProfilePage",
  "mainEntity": {
    "@type": "Person",
    "description": "Louise Callaghan is the multi-award-winning US correspondent at The Sunday Times, based in New York. She was previously Middle East correspondent, based in Istanbul and reporting from Turkey, Syria, I",
    "image": "https://www.thetimes.com/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F91369043-7523-4c65-b92d-d961b9b6cb13.png?format=webp",
    "jobTitle": "Columnist",
    "name": "Louise Callaghan",
    "url": "https://www.thetimes.com/profile/louise-callaghan "
  }
}
```
[JIRA-614](https://nidigitalsolutions.jira.com/browse/TMPR-614)


### Checklist

- [x] Have you done any manual testing?
- [ ] Does it have automated tests?
- [ ] Do you need any other PRs merged before this (if so please list)?
- [ ] Do you need to update the README/Runbook
- [ ] Have you checked for [accessibility](https://nidigitalsolutions.jira.com/wiki/spaces/TNLDigital/pages/3898048523/Accessibility+Dev+Guide#Checklist)?


### Screenshots (if appropriate):

Include screenshots if needed.
